### PR TITLE
Fix of broken path to protocol gateway .dlls

### DIFF
--- a/samples/ProtocolGateway.Samples.Cloud.Host/ProtocolGateway.Samples.Cloud.Host.csproj
+++ b/samples/ProtocolGateway.Samples.Cloud.Host/ProtocolGateway.Samples.Cloud.Host.csproj
@@ -67,12 +67,12 @@
       <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.0-preview-002\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-001\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-001\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/samples/ProtocolGateway.Samples.Common/ProtocolGateway.Samples.Common.csproj
+++ b/samples/ProtocolGateway.Samples.Common/ProtocolGateway.Samples.Common.csproj
@@ -64,11 +64,12 @@
       <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.0-preview-002\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-001\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-001\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/samples/ProtocolGateway.Samples.Console/ProtocolGateway.Samples.Console.csproj
+++ b/samples/ProtocolGateway.Samples.Console/ProtocolGateway.Samples.Console.csproj
@@ -68,12 +68,12 @@
       <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.0-preview-002\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-001\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-001\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
Motivation:

#12 Deploying Cloud Sample - References not correct

Modifications:

Paths point to a newer package version folder.

Result:

Solution build is fixed