### PR TITLE
Auth result.identity

### DIFF
--- a/ProtocolGateway.nuspec
+++ b/ProtocolGateway.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Devices.ProtocolGateway</id>
-    <version>1.0.0-preview-002</version>
+    <version>1.0.0-preview-003</version>
     <title>Microsoft Azure IoT protocol gateway framework</title>
     <authors>Microsoft Azure</authors>
     <owners>Microsoft Azure</owners>

--- a/samples/ProtocolGateway.Samples.Cloud.Host/ProtocolGateway.Samples.Cloud.Host.csproj
+++ b/samples/ProtocolGateway.Samples.Cloud.Host/ProtocolGateway.Samples.Cloud.Host.csproj
@@ -67,11 +67,11 @@
       <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.0-preview-002\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/samples/ProtocolGateway.Samples.Cloud.Host/packages.config
+++ b/samples/ProtocolGateway.Samples.Cloud.Host/packages.config
@@ -11,7 +11,7 @@
   <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="2.0.1406.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.0.0-preview-002" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.0-preview-002" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-002" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-003" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />

--- a/samples/ProtocolGateway.Samples.Common/ProtocolGateway.Samples.Common.csproj
+++ b/samples/ProtocolGateway.Samples.Common/ProtocolGateway.Samples.Common.csproj
@@ -64,11 +64,11 @@
       <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.0-preview-002\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/samples/ProtocolGateway.Samples.Common/packages.config
+++ b/samples/ProtocolGateway.Samples.Common/packages.config
@@ -8,7 +8,7 @@
   <package id="DotNetty.Transport" version="0.1.3" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.0.0-preview-002" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.0-preview-002" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-002" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-003" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />

--- a/samples/ProtocolGateway.Samples.Console/ProtocolGateway.Samples.Console.csproj
+++ b/samples/ProtocolGateway.Samples.Console/ProtocolGateway.Samples.Console.csproj
@@ -68,11 +68,11 @@
       <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.0-preview-002\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-002\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/samples/ProtocolGateway.Samples.Console/packages.config
+++ b/samples/ProtocolGateway.Samples.Console/packages.config
@@ -11,7 +11,7 @@
   <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.0.0-preview-002" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.0-preview-002" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-002" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-003" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />

--- a/src/ProtocolGateway.Core/Mqtt/Auth/AuthenticationResult.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Auth/AuthenticationResult.cs
@@ -3,25 +3,62 @@
 
 namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
 {
-    public sealed class AuthenticationResult
+    public sealed class AuthenticationProperties
     {
-        static readonly AuthenticationResult FailedResult = new AuthenticationResult
+        public static AuthenticationProperties SuccessWithSasToken(string token)
         {
-            IsSuccessful = false
-        };
-
-        public static AuthenticationResult Failure()
-        {
-            return FailedResult;
+            return new AuthenticationProperties
+            {
+                Scope = AuthenticationScope.SasToken,
+                Secret = token,
+            };
         }
 
+        public static AuthenticationProperties SuccessWithHubKey(string keyName, string keyValue)
+        {
+            return new AuthenticationProperties
+            {
+                Scope = AuthenticationScope.HubKey,
+                PolicyName = keyName,
+                Secret = keyValue
+            };
+        }
+
+        public static AuthenticationProperties SuccessWithDeviceKey(string keyValue)
+        {
+            return new AuthenticationProperties
+            {
+                Scope = AuthenticationScope.DeviceKey,
+                Secret = keyValue
+            };
+        }
+
+        public static AuthenticationProperties SuccessWithDefaultCredentials()
+        {
+            return new AuthenticationProperties
+            {
+                Scope = AuthenticationScope.None
+            };
+        }
+
+        AuthenticationProperties()
+        {
+        }
+
+        public string PolicyName { get; private set; }
+        
+        public string Secret { get; private set; }
+
+        public AuthenticationScope Scope { get; private set; }
+    }
+
+    public sealed class AuthenticationResult
+    {
         public static AuthenticationResult SuccessWithSasToken(Identity identity, string token)
         {
             return new AuthenticationResult
             {
-                IsSuccessful = true,
-                Scope = AuthenticationScope.SasToken,
-                Secret = token,
+                Properties = AuthenticationProperties.SuccessWithSasToken(token),
                 Identity = identity
             };
         }
@@ -30,11 +67,8 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
         {
             return new AuthenticationResult
             {
-                IsSuccessful = true,
                 Identity = identity,
-                Scope = AuthenticationScope.HubKey,
-                PolicyName = keyName,
-                Secret = keyValue
+                Properties = AuthenticationProperties.SuccessWithHubKey(keyName, keyValue)
             };
         }
 
@@ -42,10 +76,8 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
         {
             return new AuthenticationResult
             {
-                IsSuccessful = true,
                 Identity = identity,
-                Scope = AuthenticationScope.DeviceKey,
-                Secret = keyValue
+                Properties = AuthenticationProperties.SuccessWithDeviceKey(keyValue)
             };
         }
 
@@ -53,9 +85,8 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
         {
             return new AuthenticationResult
             {
-                IsSuccessful = true,
                 Identity = identity,
-                Scope = AuthenticationScope.None
+                Properties = AuthenticationProperties.SuccessWithDefaultCredentials()
             };
         }
 
@@ -63,13 +94,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
         {
         }
 
-        public bool IsSuccessful { get; private set; }
-
-        public string PolicyName { get; private set; }
-        
-        public string Secret { get; private set; }
-
-        public AuthenticationScope Scope { get; private set; }
+        public AuthenticationProperties Properties { get; private set; }
         
         public Identity Identity { get; private set; }
     }

--- a/src/ProtocolGateway.Core/Mqtt/Auth/AuthenticationResult.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Auth/AuthenticationResult.cs
@@ -15,46 +15,46 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
             return FailedResult;
         }
 
-        public static AuthenticationResult SuccessWithSasToken(string deviceId, string token)
+        public static AuthenticationResult SuccessWithSasToken(Identity identity, string token)
         {
             return new AuthenticationResult
             {
                 IsSuccessful = true,
-                DeviceId = deviceId,
                 Scope = AuthenticationScope.SasToken,
-                Secret = token
+                Secret = token,
+                Identity = identity
             };
         }
 
-        public static AuthenticationResult SuccessWithHubKey(string deviceId, string keyName, string keyValue)
+        public static AuthenticationResult SuccessWithHubKey(Identity identity, string keyName, string keyValue)
         {
             return new AuthenticationResult
             {
                 IsSuccessful = true,
-                DeviceId = deviceId,
+                Identity = identity,
                 Scope = AuthenticationScope.HubKey,
                 PolicyName = keyName,
                 Secret = keyValue
             };
         }
 
-        public static AuthenticationResult SuccessWithDeviceKey(string deviceId, string keyValue)
+        public static AuthenticationResult SuccessWithDeviceKey(Identity identity, string keyValue)
         {
             return new AuthenticationResult
             {
                 IsSuccessful = true,
-                DeviceId = deviceId,
+                Identity = identity,
                 Scope = AuthenticationScope.DeviceKey,
                 Secret = keyValue
             };
         }
 
-        public static AuthenticationResult SuccessWithDefaultCredentials(string deviceId)
+        public static AuthenticationResult SuccessWithDefaultCredentials(Identity identity)
         {
             return new AuthenticationResult
             {
                 IsSuccessful = true,
-                DeviceId = deviceId,
+                Identity = identity,
                 Scope = AuthenticationScope.None
             };
         }
@@ -65,12 +65,12 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
 
         public bool IsSuccessful { get; private set; }
 
-        public string DeviceId { get; private set; }
-
         public string PolicyName { get; private set; }
         
         public string Secret { get; private set; }
 
         public AuthenticationScope Scope { get; private set; }
+        
+        public Identity Identity { get; private set; }
     }
 }

--- a/src/ProtocolGateway.Core/Mqtt/Auth/DeviceKeyAuthenticationProvider.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Auth/DeviceKeyAuthenticationProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
             Identity identity = Identity.Parse(username);
             if (!clientId.Equals(identity.DeviceId, StringComparison.Ordinal))
             {
-                return Task.FromResult(AuthenticationResult.Failure());
+                return Task.FromResult((AuthenticationResult)null);
             }
             return Task.FromResult(AuthenticationResult.SuccessWithDeviceKey(identity, password));
         }

--- a/src/ProtocolGateway.Core/Mqtt/Auth/DeviceKeyAuthenticationProvider.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Auth/DeviceKeyAuthenticationProvider.cs
@@ -11,11 +11,12 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
     {
         public Task<AuthenticationResult> AuthenticateAsync(string clientId, string username, string password, EndPoint clientAddress)
         {
-            if (!clientId.Equals(username, StringComparison.Ordinal))
+            Identity identity = Identity.Parse(username);
+            if (!clientId.Equals(identity.DeviceId, StringComparison.Ordinal))
             {
                 return Task.FromResult(AuthenticationResult.Failure());
             }
-            return Task.FromResult(AuthenticationResult.SuccessWithDeviceKey(clientId, password));
+            return Task.FromResult(AuthenticationResult.SuccessWithDeviceKey(identity, password));
         }
     }
 }

--- a/src/ProtocolGateway.Core/Mqtt/Auth/Identity.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Auth/Identity.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
+{
+    using System;
+
+    public sealed class Identity
+    {
+        public string IoTHubName { get; private set; }
+
+        public string DeviceId { get; private set; }
+
+        public Identity(string iotHubName, string deviceId)
+        {
+            this.IoTHubName = iotHubName;
+            this.DeviceId = deviceId;
+        }
+
+        public override string ToString()
+        {
+            return this.IoTHubName + "/" + this.DeviceId;
+        }
+
+        public static Identity Parse(string username)
+        {
+            int delimiterPos = username.IndexOf("/", StringComparison.Ordinal);
+            string iotHubName = username.Substring(0, delimiterPos).Substring(0, username.IndexOf('.'));
+            string deviceId = username.Substring(delimiterPos + 1);
+
+            return new Identity(iotHubName, deviceId);
+        }
+    }
+}

--- a/src/ProtocolGateway.Core/Mqtt/Auth/Identity.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Auth/Identity.cs
@@ -25,7 +25,11 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
         public static Identity Parse(string username)
         {
             int delimiterPos = username.IndexOf("/", StringComparison.Ordinal);
-            string iotHubName = username.Substring(0, delimiterPos).Substring(0, username.IndexOf('.'));
+            if (delimiterPos < 0)
+            {
+                throw new FormatException(string.Format("Invalid username format: {0}", username));
+            }
+            string iotHubName = username.Substring(0, delimiterPos);
             string deviceId = username.Substring(delimiterPos + 1);
 
             return new Identity(iotHubName, deviceId);

--- a/src/ProtocolGateway.Core/Mqtt/Auth/Identity.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Auth/Identity.cs
@@ -7,19 +7,19 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
 
     public sealed class Identity
     {
-        public string IoTHubName { get; private set; }
+        public string IoTHubHostName { get; private set; }
 
         public string DeviceId { get; private set; }
 
-        public Identity(string iotHubName, string deviceId)
+        public Identity(string iotHubHostName, string deviceId)
         {
-            this.IoTHubName = iotHubName;
+            this.IoTHubHostName = iotHubHostName;
             this.DeviceId = deviceId;
         }
 
         public override string ToString()
         {
-            return this.IoTHubName + "/" + this.DeviceId;
+            return this.IoTHubHostName + "/" + this.DeviceId;
         }
 
         public static Identity Parse(string username)

--- a/src/ProtocolGateway.Core/Mqtt/Auth/SasTokenAuthenticationProvider.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Auth/SasTokenAuthenticationProvider.cs
@@ -11,11 +11,12 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
     {
         public Task<AuthenticationResult> AuthenticateAsync(string clientId, string username, string password, EndPoint clientAddress)
         {
-            if (!clientId.Equals(username, StringComparison.Ordinal))
+            Identity identity = Identity.Parse(username);
+            if (!clientId.Equals(identity.DeviceId, StringComparison.Ordinal))
             {
                 return Task.FromResult(AuthenticationResult.Failure());
             }
-            return Task.FromResult(AuthenticationResult.SuccessWithSasToken(clientId, password));
+            return Task.FromResult(AuthenticationResult.SuccessWithSasToken(identity, password));
         }
     }
 }

--- a/src/ProtocolGateway.Core/Mqtt/Auth/SasTokenAuthenticationProvider.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Auth/SasTokenAuthenticationProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Auth
             Identity identity = Identity.Parse(username);
             if (!clientId.Equals(identity.DeviceId, StringComparison.Ordinal))
             {
-                return Task.FromResult(AuthenticationResult.Failure());
+                return Task.FromResult((AuthenticationResult)null);
             }
             return Task.FromResult(AuthenticationResult.SuccessWithSasToken(identity, password));
         }

--- a/src/ProtocolGateway.Core/Mqtt/IotHubDeviceClient.cs
+++ b/src/ProtocolGateway.Core/Mqtt/IotHubDeviceClient.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                 }
                 //csb.GroupName = connectionIds[connectionIndex]; // todo: uncommment once explicit control over connection pooling is available
                 csb.AuthenticationMethod = Util.DeriveAuthenticationMethod(csb.AuthenticationMethod, deviceCredentials);
+                csb.HostName = deviceCredentials.Identity.IoTHubHostName;
                 string connectionString = csb.ToString();
                 return CreateFromConnectionStringAsync(connectionString);
             };

--- a/src/ProtocolGateway.Core/Mqtt/MqttIotHubAdapter.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MqttIotHubAdapter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
         readonly RequestAckPairProcessor<CompletionPendingMessageState, PubRelPacket> pubRelPubCompProcessor;
         readonly ITopicNameRouter topicNameRouter;
         Dictionary<string, string> sessionContext;
-        string deviceId;
+        Identity identity;
         readonly IQos2StatePersistenceProvider qos2StateProvider;
         readonly QualityOfService maxSupportedQosToClient;
         TimeSpan keepAliveTimeout;
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                 {
                     MqttIotHubAdapterEventSource.Log.Verbose(
                         "Not reading per full inbound message queue",
-                        string.Format("deviceId: {0}, messages queued: {1}, channel: {2}", this.deviceId, inboundBacklogSize, context.Channel));
+                        string.Format("deviceId: {0}, messages queued: {1}, channel: {2}", this.identity, inboundBacklogSize, context.Channel));
                 }
             }
         }
@@ -254,7 +254,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                         .OnFault(ShutdownOnWriteFaultAction, context);
                     break;
                 case PacketType.DISCONNECT:
-                    MqttIotHubAdapterEventSource.Log.Verbose("Disconnecting gracefully.", this.deviceId);
+                    MqttIotHubAdapterEventSource.Log.Verbose("Disconnecting gracefully.", this.identity.ToString());
                     this.Shutdown(context, true);
                     break;
                 default:
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                     if (!this.sessionState.IsTransient)
                     {
                         // save updated session state, make it current once successfully set
-                        await this.sessionStateManager.SetAsync(this.deviceId, newState);
+                        await this.sessionStateManager.SetAsync(this.identity.ToString(), newState);
                     }
 
                     this.sessionState = newState;
@@ -385,7 +385,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             {
                 if (MqttIotHubAdapterEventSource.Log.IsVerboseEnabled)
                 {
-                    MqttIotHubAdapterEventSource.Log.Verbose("Resuming reading from channel as queue freed up.", string.Format("deviceId: {0}, channel: {1}", this.deviceId, context.Channel));
+                    MqttIotHubAdapterEventSource.Log.Verbose("Resuming reading from channel as queue freed up.", string.Format("deviceId: {0}, channel: {1}", this.identity, context.Channel));
                 }
                 context.Read();
             }
@@ -400,11 +400,11 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                 string messageDeviceId;
                 if (message.Properties.TryGetValue(DeviceIdParam, out messageDeviceId))
                 {
-                    if (!this.deviceId.Equals(messageDeviceId, StringComparison.Ordinal))
+                    if (!this.identity.DeviceId.Equals(messageDeviceId, StringComparison.Ordinal))
                     {
-                        throw new InvalidOperationException(string.Format("Device ID provided in topic name ({0}) does not match ID of the device publishing message ({1}).",
-                            messageDeviceId,
-                            this.deviceId));
+                        throw new InvalidOperationException(
+                            string.Format("Device ID provided in topic name ({0}) does not match ID of the device publishing message ({1}). IoT Hub Name: {2}",
+                            messageDeviceId, this.identity.DeviceId, this.identity.IoTHubName));
                     }
                     message.Properties.Remove(DeviceIdParam);
                 }
@@ -881,11 +881,11 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                     return;
                 }
 
-                this.deviceId = authResult.DeviceId;
+                this.identity = authResult.Identity;
 
                 this.iotHubClient = await this.deviceClientFactory(authResult);
 
-                bool sessionPresent = await this.EstablishSessionStateAsync(this.deviceId, packet.CleanSession);
+                bool sessionPresent = await this.EstablishSessionStateAsync(this.identity.ToString(), packet.CleanSession);
 
                 this.keepAliveTimeout = this.DeriveKeepAliveTimeout(packet);
 
@@ -899,7 +899,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
 
                 this.sessionContext = new Dictionary<string, string>
                 {
-                    { DeviceIdParam, this.deviceId }
+                    { DeviceIdParam, this.identity.DeviceId }
                 };
 
                 this.StartReceiving(context);
@@ -1000,7 +1000,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
         /// <param name="context"><see cref="IChannelHandlerContext" /> instance.</param>
         void CompleteConnect(IChannelHandlerContext context)
         {
-            MqttIotHubAdapterEventSource.Log.Verbose("Connection established.", this.deviceId);
+            MqttIotHubAdapterEventSource.Log.Verbose("Connection established.", this.identity.ToString());
 
             if (this.keepAliveTimeout > TimeSpan.Zero)
             {
@@ -1071,7 +1071,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             if (!self.IsInState(StateFlags.Closed))
             {
                 PerformanceCounters.ConnectionFailedOperationalPerSecond.Increment();
-                MqttIotHubAdapterEventSource.Log.Warning(string.Format("Closing connection ({0}, {1}): {2}", context.Channel.RemoteAddress, self.deviceId, reason));
+                MqttIotHubAdapterEventSource.Log.Warning(string.Format("Closing connection ({0}, {1}): {2}", context.Channel.RemoteAddress, self.identity, reason));
                 self.Shutdown(context, false);
             }
         }

--- a/src/ProtocolGateway.Core/Mqtt/MqttIotHubAdapter.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MqttIotHubAdapter.cs
@@ -404,7 +404,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                     {
                         throw new InvalidOperationException(
                             string.Format("Device ID provided in topic name ({0}) does not match ID of the device publishing message ({1}). IoT Hub Name: {2}",
-                            messageDeviceId, this.identity.DeviceId, this.identity.IoTHubName));
+                            messageDeviceId, this.identity.DeviceId, this.identity.IoTHubHostName));
                     }
                     message.Properties.Remove(DeviceIdParam);
                 }
@@ -869,7 +869,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                 this.stateFlags = StateFlags.ProcessingConnect;
                 AuthenticationResult authResult = await this.authProvider.AuthenticateAsync(packet.ClientId,
                     packet.Username, packet.Password, context.Channel.RemoteAddress);
-                if (!authResult.IsSuccessful)
+                if (authResult == null)
                 {
                     connAckSent = true;
                     await Util.WriteMessageAsync(context, new ConnAckPacket

--- a/src/ProtocolGateway.Core/Mqtt/Util.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Util.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
 
         internal static IAuthenticationMethod DeriveAuthenticationMethod(IAuthenticationMethod currentAuthenticationMethod, AuthenticationResult authenticationResult)
         {
-            string deviceId = authenticationResult.Identity.ToString();
+            string deviceId = authenticationResult.Identity.DeviceId;
             switch (authenticationResult.Properties.Scope)
             {
                 case AuthenticationScope.None:

--- a/src/ProtocolGateway.Core/Mqtt/Util.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Util.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
 
         internal static IAuthenticationMethod DeriveAuthenticationMethod(IAuthenticationMethod currentAuthenticationMethod, AuthenticationResult deviceCredentials)
         {
-            string deviceId = deviceCredentials.DeviceId;
+            string deviceId = deviceCredentials.Identity.ToString();
             switch (deviceCredentials.Scope)
             {
                 case AuthenticationScope.None:

--- a/src/ProtocolGateway.Core/Mqtt/Util.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Util.cs
@@ -166,10 +166,10 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             return packet;
         }
 
-        internal static IAuthenticationMethod DeriveAuthenticationMethod(IAuthenticationMethod currentAuthenticationMethod, AuthenticationResult deviceCredentials)
+        internal static IAuthenticationMethod DeriveAuthenticationMethod(IAuthenticationMethod currentAuthenticationMethod, AuthenticationResult authenticationResult)
         {
-            string deviceId = deviceCredentials.Identity.ToString();
-            switch (deviceCredentials.Scope)
+            string deviceId = authenticationResult.Identity.ToString();
+            switch (authenticationResult.Properties.Scope)
             {
                 case AuthenticationScope.None:
                     var policyKeyAuth = currentAuthenticationMethod as DeviceAuthenticationWithSharedAccessPolicyKey;
@@ -189,13 +189,13 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                     }
                     throw new InvalidOperationException("");
                 case AuthenticationScope.SasToken:
-                    return new DeviceAuthenticationWithToken(deviceId, deviceCredentials.Secret);
+                    return new DeviceAuthenticationWithToken(deviceId, authenticationResult.Properties.Secret);
                 case AuthenticationScope.DeviceKey:
-                    return new DeviceAuthenticationWithRegistrySymmetricKey(deviceId, deviceCredentials.Secret);
+                    return new DeviceAuthenticationWithRegistrySymmetricKey(deviceId, authenticationResult.Properties.Secret);
                 case AuthenticationScope.HubKey:
-                    return new DeviceAuthenticationWithSharedAccessPolicyKey(deviceId, deviceCredentials.PolicyName, deviceCredentials.Secret);
+                    return new DeviceAuthenticationWithSharedAccessPolicyKey(deviceId, authenticationResult.Properties.PolicyName, authenticationResult.Properties.Secret);
                 default:
-                    throw new InvalidOperationException("Unexpected AuthenticationScope value: " + deviceCredentials.Scope);
+                    throw new InvalidOperationException("Unexpected AuthenticationScope value: " + authenticationResult.Properties.Scope);
             }
         }
 

--- a/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
+++ b/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Instrumentation\MqttIotHubAdapterEventSource.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="Mqtt\AckPendingMessageState.cs" />
+    <Compile Include="Mqtt\Auth\Identity.cs" />
     <Compile Include="Mqtt\PacketAsyncProcessorBase.cs" />
     <Compile Include="Mqtt\Auth\DeviceKeyAuthenticationProvider.cs" />
     <Compile Include="Mqtt\ChannelMessageProcessingException.cs" />


### PR DESCRIPTION
We need to teach Protocol Gateway to work in multi-tenant environment

Motivation:

Hosting one protocol gateway that will handle requests to many IoT Hubs wasn't possible because the providing connect information doesn't have a notion about IoT Hub itself. It works in context of device only.

Modifications:

AuthenticationResult that IAuthenticationProvider returns has been changed

Result:

It may require to fix your custom IAuthenticationProvider implementation 