### PR TITLE
Update DotNetty to a newer version.

### DIFF
--- a/ProtocolGateway.nuspec
+++ b/ProtocolGateway.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Devices.ProtocolGateway</id>
-    <version>1.0.0-preview-003</version>
+    <version>1.0.0-preview-004</version>
     <title>Microsoft Azure IoT protocol gateway framework</title>
     <authors>Microsoft Azure</authors>
     <owners>Microsoft Azure</owners>

--- a/samples/ProtocolGateway.Samples.Cloud.Host/ProtocolGateway.Samples.Cloud.Host.csproj
+++ b/samples/ProtocolGateway.Samples.Cloud.Host/ProtocolGateway.Samples.Cloud.Host.csproj
@@ -34,29 +34,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Buffers.0.1.3\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.2.1\lib\net45\DotNetty.Buffers.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Codecs.0.1.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.2.1\lib\net45\DotNetty.Codecs.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.1.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.2.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Common.0.1.3\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.2.1\lib\net45\DotNetty.Common.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Handlers.0.1.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers.0.2.1\lib\net45\DotNetty.Handlers.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Transport.0.1.3\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.2.1\lib\net45\DotNetty.Transport.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -67,11 +67,11 @@
       <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.0-preview-002\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-004\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-004\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/samples/ProtocolGateway.Samples.Cloud.Host/WorkerRole.cs
+++ b/samples/ProtocolGateway.Samples.Cloud.Host/WorkerRole.cs
@@ -9,10 +9,7 @@ namespace ProtocolGateway.Samples.Cloud.Host
     using System.Security.Cryptography.X509Certificates;
     using System.Threading;
     using System.Threading.Tasks;
-    using DotNetty.Codecs.Mqtt;
-    using DotNetty.Common.Concurrency;
-    using DotNetty.Transport.Bootstrapping;
-    using DotNetty.Transport.Channels;
+    using DotNetty.Common.Internal.Logging;
     using Microsoft.Azure.Devices.ProtocolGateway;
     using Microsoft.Azure.Devices.ProtocolGateway.Instrumentation;
     using Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage;
@@ -71,11 +68,8 @@ namespace ProtocolGateway.Samples.Cloud.Host
             eventListener.LogToWindowsAzureTable(RoleEnvironment.CurrentRoleInstance.Id, settingsProvider.GetSetting("BlobSessionStatePersistenceProvider.StorageConnectionString"), bufferingInterval: TimeSpan.FromMinutes(2));
             eventListener.EnableEvents(BootstrapperEventSource.Log, EventLevel.Informational);
             eventListener.EnableEvents(MqttIotHubAdapterEventSource.Log, EventLevel.Informational);
-            eventListener.EnableEvents(ChannelEventSource.Log, EventLevel.Informational);
-            eventListener.EnableEvents(BootstrapEventSource.Log, EventLevel.Informational);
-            eventListener.EnableEvents(ExecutorEventSource.Log, EventLevel.Informational);
-            eventListener.EnableEvents(MqttEventSource.Log, EventLevel.Informational);
-
+            eventListener.EnableEvents(DefaultEventSource.Log, EventLevel.Informational);
+            
             int minWorkerThreads;
             int minCompletionPortThreads;
             ThreadPool.GetMinThreads(out minWorkerThreads, out minCompletionPortThreads);

--- a/samples/ProtocolGateway.Samples.Cloud.Host/packages.config
+++ b/samples/ProtocolGateway.Samples.Cloud.Host/packages.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Common" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Handlers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Transport" version="0.1.3" targetFramework="net451" />
+  <package id="DotNetty.Buffers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Common" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Transport" version="0.2.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="2.0.1406.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.0.0-preview-002" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.0-preview-002" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-003" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-004" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />

--- a/samples/ProtocolGateway.Samples.Cloud/ProtocolGateway.Samples.Cloud.HostContent/diagnostics.wadcfgx
+++ b/samples/ProtocolGateway.Samples.Cloud/ProtocolGateway.Samples.Cloud.HostContent/diagnostics.wadcfgx
@@ -9,6 +9,7 @@
           <PerformanceCounterConfiguration counterSpecifier="\Processor(_Total)\% Processor Time" sampleRate="PT30S" />
           <PerformanceCounterConfiguration counterSpecifier="\Memory\Available MBytes" sampleRate="PT30S" />
           <PerformanceCounterConfiguration counterSpecifier="\Process(WaWorkerHost)\% Processor Time" sampleRate="PT30S" />
+          <PerformanceCounterConfiguration counterSpecifier="\Process(WaIISHost)\Private Bytes" sampleRate="PT30S" />
           <PerformanceCounterConfiguration counterSpecifier="\Process(WaWorkerHost)\Private Bytes" sampleRate="PT30S" />
           <PerformanceCounterConfiguration counterSpecifier="\Process(WaWorkerHost)\Thread Count" sampleRate="PT30S" />
           <PerformanceCounterConfiguration counterSpecifier="\.NET CLR Memory(_Global_)\% Time in GC" sampleRate="PT30S" />

--- a/samples/ProtocolGateway.Samples.Common/ProtocolGateway.Samples.Common.csproj
+++ b/samples/ProtocolGateway.Samples.Common/ProtocolGateway.Samples.Common.csproj
@@ -31,29 +31,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Buffers.0.1.3\lib\net45\DotNetty.Buffers.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Codecs.0.1.3\lib\net45\DotNetty.Codecs.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.1.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Common, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Common.0.1.3\lib\net45\DotNetty.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Handlers">
-      <HintPath>..\..\packages\DotNetty.Handlers.0.1.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.2.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Transport.0.1.3\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.2.1\lib\net45\DotNetty.Codecs.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.2.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Common, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.2.1\lib\net45\DotNetty.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers.0.2.1\lib\net45\DotNetty.Handlers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.2.1\lib\net45\DotNetty.Transport.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -64,11 +64,11 @@
       <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.0-preview-002\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-004\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-004\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/samples/ProtocolGateway.Samples.Common/packages.config
+++ b/samples/ProtocolGateway.Samples.Common/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Common" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Handlers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Transport" version="0.1.3" targetFramework="net451" />
+  <package id="DotNetty.Buffers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Common" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Transport" version="0.2.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.0.0-preview-002" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.0-preview-002" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-003" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-004" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />

--- a/samples/ProtocolGateway.Samples.Console/Program.cs
+++ b/samples/ProtocolGateway.Samples.Console/Program.cs
@@ -8,10 +8,7 @@ namespace ProtocolGateway.Samples.Console
     using System.Security.Cryptography.X509Certificates;
     using System.Threading;
     using System.Threading.Tasks;
-    using DotNetty.Codecs.Mqtt;
-    using DotNetty.Common.Concurrency;
-    using DotNetty.Transport.Bootstrapping;
-    using DotNetty.Transport.Channels;
+    using DotNetty.Common.Internal.Logging;
     using Microsoft.Azure.Devices.ProtocolGateway;
     using Microsoft.Azure.Devices.ProtocolGateway.Instrumentation;
     using Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage;
@@ -38,11 +35,8 @@ namespace ProtocolGateway.Samples.Console
             eventListener.LogToConsole();
             eventListener.EnableEvents(BootstrapperEventSource.Log, EventLevel.Verbose);
             eventListener.EnableEvents(MqttIotHubAdapterEventSource.Log, EventLevel.Verbose);
-            eventListener.EnableEvents(ChannelEventSource.Log, EventLevel.Verbose);
-            eventListener.EnableEvents(BootstrapEventSource.Log, EventLevel.Verbose);
-            eventListener.EnableEvents(ExecutorEventSource.Log, EventLevel.Verbose);
-            eventListener.EnableEvents(MqttEventSource.Log, EventLevel.Verbose);
-
+            eventListener.EnableEvents(DefaultEventSource.Log, EventLevel.Verbose);
+            
             try
             {
                 var cts = new CancellationTokenSource();

--- a/samples/ProtocolGateway.Samples.Console/ProtocolGateway.Samples.Console.csproj
+++ b/samples/ProtocolGateway.Samples.Console/ProtocolGateway.Samples.Console.csproj
@@ -35,29 +35,29 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Buffers.0.1.3\lib\net45\DotNetty.Buffers.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Codecs.0.1.3\lib\net45\DotNetty.Codecs.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.1.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Common, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Common.0.1.3\lib\net45\DotNetty.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Handlers">
-      <HintPath>..\..\packages\DotNetty.Handlers.0.1.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.2.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Transport.0.1.3\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.2.1\lib\net45\DotNetty.Codecs.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.2.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Common, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.2.1\lib\net45\DotNetty.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers.0.2.1\lib\net45\DotNetty.Handlers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.2.1\lib\net45\DotNetty.Transport.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -68,11 +68,11 @@
       <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.0-preview-002\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-004\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-003\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.1.0.0-preview-004\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/samples/ProtocolGateway.Samples.Console/packages.config
+++ b/samples/ProtocolGateway.Samples.Console/packages.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net451" />
-  <package id="DotNetty.Buffers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Common" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Handlers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Transport" version="0.1.3" targetFramework="net451" />
+  <package id="DotNetty.Buffers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Common" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Transport" version="0.2.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.0.0-preview-002" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.0-preview-002" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-003" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway" version="1.0.0-preview-004" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />

--- a/src/ProtocolGateway.Core/Mqtt/MqttIotHubAdapter.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MqttIotHubAdapter.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             TimeSpan? timeout = this.settings.ConnectArrivalTimeout;
             if (timeout.HasValue)
             {
-                context.Channel.EventLoop.Schedule(CheckConnectTimeoutCallback, context, timeout.Value);
+                context.Channel.EventLoop.ScheduleAsync(CheckConnectTimeoutCallback, context, timeout.Value);
             }
             base.ChannelActive(context);
 
@@ -1045,7 +1045,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                 return;
             }
 
-            context.Channel.EventLoop.Schedule(CheckKeepAliveCallback, context, self.keepAliveTimeout - elapsedSinceLastActive);
+            context.Channel.EventLoop.ScheduleAsync(CheckKeepAliveCallback, context, self.keepAliveTimeout - elapsedSinceLastActive);
         }
 
         static void ShutdownOnError(IChannelHandlerContext context, string scope, Exception exception)

--- a/src/ProtocolGateway.Core/Mqtt/RequestAckPairProcessor.cs
+++ b/src/ProtocolGateway.Core/Mqtt/RequestAckPairProcessor.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             if (!this.retransmissionCheckScheduled)
             {
                 this.retransmissionCheckScheduled = true;
-                context.Channel.EventLoop.Schedule(StartRetransmissionIfNeededCallback, context, this, delay);
+                context.Channel.EventLoop.ScheduleAsync(StartRetransmissionIfNeededCallback, context, this, delay);
             }
         }
 

--- a/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
+++ b/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
@@ -32,29 +32,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Buffers.0.1.3\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.2.1\lib\net45\DotNetty.Buffers.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Codecs.0.1.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.2.1\lib\net45\DotNetty.Codecs.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.1.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.2.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Common.0.1.3\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.2.1\lib\net45\DotNetty.Common.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Handlers.0.1.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers.0.2.1\lib\net45\DotNetty.Handlers.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Transport.0.1.3\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.2.1\lib\net45\DotNetty.Transport.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.0.0-preview-002\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>

--- a/src/ProtocolGateway.Core/packages.config
+++ b/src/ProtocolGateway.Core/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Common" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Handlers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Transport" version="0.1.3" targetFramework="net451" />
+  <package id="DotNetty.Buffers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Common" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Transport" version="0.2.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.0.0-preview-002" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.0-preview-002" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />

--- a/test/ProtocolGateway.Tests.Load/ProtocolGateway.Tests.Load.csproj
+++ b/test/ProtocolGateway.Tests.Load/ProtocolGateway.Tests.Load.csproj
@@ -40,29 +40,29 @@
       <HintPath>..\..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Buffers, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Buffers.0.1.3\lib\net45\DotNetty.Buffers.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Codecs">
-      <HintPath>..\..\packages\DotNetty.Codecs.0.1.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.2.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.1.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Common">
-      <HintPath>..\..\packages\DotNetty.Common.0.1.3\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.2.1\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Handlers.0.1.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.2.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Transport.0.1.3\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.2.1\lib\net45\DotNetty.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers.0.2.1\lib\net45\DotNetty.Handlers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.2.1\lib\net45\DotNetty.Transport.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.0.0-preview-002\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>

--- a/test/ProtocolGateway.Tests.Load/packages.config
+++ b/test/ProtocolGateway.Tests.Load/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Common" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Handlers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Transport" version="0.1.3" targetFramework="net451" />
   <package id="CommandLineParser" version="1.9.71" targetFramework="net452" />
+  <package id="DotNetty.Buffers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Common" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Transport" version="0.2.1" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.Azure.Amqp" version="1.0.0-preview-002" targetFramework="net452" />

--- a/test/ProtocolGateway.Tests/EndToEndTests.cs
+++ b/test/ProtocolGateway.Tests/EndToEndTests.cs
@@ -17,10 +17,12 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Tests
     using DotNetty.Codecs.Mqtt;
     using DotNetty.Codecs.Mqtt.Packets;
     using DotNetty.Common.Concurrency;
+    using DotNetty.Common.Internal.Logging;
     using DotNetty.Handlers.Tls;
     using DotNetty.Transport.Bootstrapping;
     using DotNetty.Transport.Channels;
     using DotNetty.Transport.Channels.Sockets;
+    using global::ProtocolGateway.Samples.Common;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Common.Security;
     using Microsoft.Azure.Devices.Gateway.Tests;
@@ -62,11 +64,9 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Tests
             this.eventListener = new ObservableEventListener();
             this.eventListener.LogToTestOutput(output);
             this.eventListener.EnableEvents(MqttIotHubAdapterEventSource.Log, EventLevel.Verbose);
-            this.eventListener.EnableEvents(ChannelEventSource.Log, EventLevel.Verbose);
-            this.eventListener.EnableEvents(BootstrapEventSource.Log, EventLevel.Verbose);
-            this.eventListener.EnableEvents(ExecutorEventSource.Log, EventLevel.Verbose);
-            this.eventListener.EnableEvents(MqttEventSource.Log, EventLevel.Verbose);
-
+            this.eventListener.EnableEvents(DefaultEventSource.Log, EventLevel.Verbose);
+            this.eventListener.EnableEvents(BootstrapperEventSource.Log, EventLevel.Verbose);
+            
             this.settingsProvider = new AppConfigSettingsProvider();
 
             this.ProtocolGatewayPort = 8883; // todo: dynamic port choice to parallelize test runs (first free port)

--- a/test/ProtocolGateway.Tests/ProtocolGateway.Tests.csproj
+++ b/test/ProtocolGateway.Tests/ProtocolGateway.Tests.csproj
@@ -41,29 +41,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Buffers.0.1.3\lib\net45\DotNetty.Buffers.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Codecs">
-      <HintPath>..\..\packages\DotNetty.Codecs.0.1.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.2.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.1.3\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetty.Common">
-      <HintPath>..\..\packages\DotNetty.Common.0.1.3\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.2.1\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Handlers.0.1.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt.0.2.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DotNetty.Transport.0.1.3\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.2.1\lib\net45\DotNetty.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers.0.2.1\lib\net45\DotNetty.Handlers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.2.1\lib\net45\DotNetty.Transport.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.0.0-preview-002\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>

--- a/test/ProtocolGateway.Tests/TestScenarioRunner.cs
+++ b/test/ProtocolGateway.Tests/TestScenarioRunner.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Gateway.Tests
 
             if (currentStep.Delay > TimeSpan.Zero)
             {
-                context.Channel.EventLoop.Schedule((ctx, state) => this.ExecuteStep((IChannelHandlerContext)ctx, (TestScenarioStep)state), context, currentStep, currentStep.Delay);
+                context.Channel.EventLoop.ScheduleAsync((ctx, state) => this.ExecuteStep((IChannelHandlerContext)ctx, (TestScenarioStep)state), context, currentStep, currentStep.Delay);
             }
             else
             {
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Devices.Gateway.Tests
                 var writeTimeoutCts = new CancellationTokenSource();
                 Task task = context.WriteAsync(message);
                 object timeoutExcMessage = message;
-                context.Channel.EventLoop.Schedule(
+                context.Channel.EventLoop.ScheduleAsync(
                     () => this.completion.TrySetException(new TimeoutException(string.Format("Sending of message did not complete in time: {0}", timeoutExcMessage))),
                     this.sendTimeout,
                     writeTimeoutCts.Token);
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Gateway.Tests
 
         void ScheduleReadTimeoutCheck(IChannelHandlerContext context, object lastMessage)
         {
-            context.Channel.EventLoop.Schedule(
+            context.Channel.EventLoop.ScheduleAsync(
                 () => this.completion.TrySetException(new TimeoutException(string.Format("Timed out waiting for response to {0} message.", lastMessage))),
                 this.responseTimeout,
                 this.responseTimeoutCts.Token);

--- a/test/ProtocolGateway.Tests/packages.config
+++ b/test/ProtocolGateway.Tests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Common" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Handlers" version="0.1.3" targetFramework="net451" />
-  <package id="DotNetty.Transport" version="0.1.3" targetFramework="net451" />
+  <package id="DotNetty.Buffers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Common" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers" version="0.2.1" targetFramework="net451" />
+  <package id="DotNetty.Transport" version="0.2.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer" version="2.0.1406.1" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />


### PR DESCRIPTION
Motivation:

Simplifies and improves logging experience.

Modifications:

DotNetty version has been bumped. A minor changes were done, like renaming a method name.

Result:

Number of event sources we need to listen has decreased, because they were collapsed to a single DefaultEventSource