### PR TITLE
Assing GUID to event source

### DIFF
--- a/samples/ProtocolGateway.Samples.Common/BootstrapperEventSource.cs
+++ b/samples/ProtocolGateway.Samples.Common/BootstrapperEventSource.cs
@@ -6,7 +6,9 @@ namespace ProtocolGateway.Samples.Common
     using System;
     using System.Diagnostics.Tracing;
 
-    [EventSource(Name = "IoT-ProtocolGateway-Bootstrapper")]
+    [EventSource(
+        Name = "IoT-ProtocolGateway-Bootstrapper",
+        Guid = "e29735c9-6796-4228-ac96-9db40faB697a")]
     public class BootstrapperEventSource : EventSource
     {
         const int VerboseEventId = 1;

--- a/src/ProtocolGateway.Core/Instrumentation/MqttIotHubAdapterEventSource.cs
+++ b/src/ProtocolGateway.Core/Instrumentation/MqttIotHubAdapterEventSource.cs
@@ -6,7 +6,9 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Instrumentation
     using System;
     using System.Diagnostics.Tracing;
 
-    [EventSource(Name = "IoT-ProtocolGateway-MqttIotHubAdapter")]
+    [EventSource(
+        Name = "IoT-ProtocolGateway-MqttIotHubAdapter",
+        Guid = "06d7118e-3a71-4143-8aab-ed8cedf69e1c")]
     public class MqttIotHubAdapterEventSource : EventSource
     {
         const int VerboseEventId = 1;


### PR DESCRIPTION
Motivation:

Guid is necessary for other systems to make a distinction between events.

Modifications:

Guids assigned to all event sources.

Result:
We have GUIDs now. Yay!