### PR TITLE
Fixes QoS 2 persistence provider, Blob-based state persistence provid…

### DIFF
--- a/src/ProtocolGateway.Core/Messaging/IMessage.cs
+++ b/src/ProtocolGateway.Core/Messaging/IMessage.cs
@@ -21,9 +21,6 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Messaging
 
         uint DeliveryCount { get; }
 
-        /// <remarks>
-        /// Only 15 least significant bits will be honored
-        /// </remarks>
-        ushort SequenceNumber { get; }
+        ulong SequenceNumber { get; }
     }
 }

--- a/src/ProtocolGateway.Core/Mqtt/AckPendingMessageState.cs
+++ b/src/ProtocolGateway.Core/Mqtt/AckPendingMessageState.cs
@@ -11,13 +11,13 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
     sealed class AckPendingMessageState : IPacketReference, ISupportRetransmission // todo: recycle?
     {
         public AckPendingMessageState(IMessage message, PublishPacket packet)
-            : this(message.MessageId, packet.PacketId, packet.QualityOfService, message.LockToken)
+            : this(message.SequenceNumber, packet.PacketId, packet.QualityOfService, message.LockToken)
         {
         }
 
-        public AckPendingMessageState(string messageId, int packetId, QualityOfService qualityOfService, string lockToken)
+        public AckPendingMessageState(ulong sequenceNumber, int packetId, QualityOfService qualityOfService, string lockToken)
         {
-            this.MessageId = messageId;
+            this.SequenceNumber = sequenceNumber;
             this.PacketId = packetId;
             this.QualityOfService = qualityOfService;
             this.LockToken = lockToken;
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
 
         public PreciseTimeSpan StartTimestamp { get; set; }
 
-        public string MessageId { get; private set; }
+        public ulong SequenceNumber { get; private set; }
 
         public int PacketId { get; private set; }
 
@@ -39,11 +39,11 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
 
         public void Reset(IMessage message)
         {
-            if (message.MessageId != this.MessageId)
+            if (message.SequenceNumber != this.SequenceNumber)
             {
                 throw new InvalidOperationException(string.Format(
                     "Expected to receive message with id of {0} but saw a message with id of {1}. Protocol Gateway only supports exclusive connection to IoT Hub.",
-                    this.MessageId, message.MessageId));
+                    this.SequenceNumber, message.MessageId));
             }
 
             this.LockToken = message.LockToken;
@@ -52,11 +52,11 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
 
         public void ResetMessage(IMessage message)
         {
-            if (message.MessageId != this.MessageId)
+            if (message.SequenceNumber != this.SequenceNumber)
             {
                 throw new InvalidOperationException(string.Format(
                     "Expected to receive message with id of {0} but saw a message with id of {1}. Protocol Gateway only supports exclusive connection to IoT Hub.",
-                    this.MessageId, message.MessageId));
+                    this.SequenceNumber.ToString(), message.MessageId));
             }
 
             this.LockToken = message.LockToken;

--- a/src/ProtocolGateway.Core/Mqtt/MqttIotHubAdapter.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MqttIotHubAdapter.cs
@@ -452,7 +452,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                 {
                     processorsInRetransmission++;
                     AckPendingMessageState pendingPubAck = this.publishPubAckProcessor.FirstRequestPendingAck;
-                    if (pendingPubAck.MessageId.Equals(message.MessageId, StringComparison.Ordinal))
+                    if (pendingPubAck.SequenceNumber == message.SequenceNumber)
                     {
                         this.RetransmitPublishMessage(context, message, pendingPubAck);
                         messageSent = true;
@@ -465,7 +465,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                     if (!messageSent)
                     {
                         AckPendingMessageState pendingPubRec = this.publishPubRecProcessor.FirstRequestPendingAck;
-                        if (pendingPubRec.MessageId.Equals(message.MessageId, StringComparison.Ordinal))
+                        if (pendingPubRec.SequenceNumber == message.SequenceNumber)
                         {
                             this.RetransmitPublishMessage(context, message, pendingPubRec);
                             messageSent = true;
@@ -617,7 +617,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             int packetId = packet.PacketId;
             IQos2MessageDeliveryState messageInfo = await this.qos2StateProvider.GetMessageAsync(this.identity, packetId);
 
-            if (messageInfo != null && !message.MessageId.Equals(messageInfo.MessageId, StringComparison.Ordinal))
+            if (messageInfo != null && message.SequenceNumber != messageInfo.SequenceNumber)
             {
                 await this.qos2StateProvider.DeleteMessageAsync(this.identity, packetId, messageInfo);
                 messageInfo = null;
@@ -675,7 +675,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             // todo: is try-catch needed here?
             try
             {
-                IQos2MessageDeliveryState messageInfo = this.qos2StateProvider.Create(message.MessageId);
+                IQos2MessageDeliveryState messageInfo = this.qos2StateProvider.Create(message.SequenceNumber);
                 await this.qos2StateProvider.SetMessageAsync(this.identity, message.PacketId, messageInfo);
 
                 await this.PublishReleaseToClientAsync(context, message.PacketId, message.LockToken, messageInfo, message.StartTimestamp);

--- a/src/ProtocolGateway.Core/Mqtt/Persistence/IQoS2MessageDeliveryState.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Persistence/IQoS2MessageDeliveryState.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Persistence
     {
         DateTime LastModified { get; }
 
-        string MessageId { get; }
+        ulong SequenceNumber { get; }
     }
 }

--- a/src/ProtocolGateway.Core/Mqtt/Persistence/IQos2StatePersistenceProvider.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Persistence/IQos2StatePersistenceProvider.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Persistence
 
     public interface IQos2StatePersistenceProvider
     {
-        IQos2MessageDeliveryState Create(string messageId);
+        IQos2MessageDeliveryState Create(ulong sequenceNumber);
 
         /// <summary>
         ///     Performs a lookup of message delivery state by packet identifier

--- a/src/ProtocolGateway.Core/Mqtt/Settings.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Settings.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             {
                 outboundMessages = MaxPendingOutboundMessagesDefaultValue;
             }
-            this.MaxPendingOutboundMessages = Math.Min(outboundMessages, ushort.MaxValue / 2); // limited due to separation of packet id domains for QoS 1 and 2.
+            this.MaxPendingOutboundMessages = Math.Min(outboundMessages, ushort.MaxValue >> 2); // limited due to separation of packet id domains for QoS 1 and 2.
 
             TimeSpan timeout;
             this.ConnectArrivalTimeout = settingsProvider.TryGetTimeSpanSetting(ConnectArrivalTimeoutSetting, out timeout) && timeout > TimeSpan.Zero

--- a/src/ProtocolGateway.Core/Mqtt/Util.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Util.cs
@@ -133,19 +133,18 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             packet.TopicName = topicName;
             if (qos > QualityOfService.AtMostOnce)
             {
-                int packetId = message.SequenceNumber;
+                int packetId = unchecked((int)message.SequenceNumber) & 0x3FFF; // clear bits #14 and #15
                 switch (qos)
                 {
                     case QualityOfService.AtLeastOnce:
-                        packetId &= 0x7FFF; // clear 15th bit
                         break;
                     case QualityOfService.ExactlyOnce:
-                        packetId |= 0x8000; // set 15th bit
+                        packetId |= 0x8000; // set bit #15
                         break;
                     default:
                         throw new ArgumentOutOfRangeException(nameof(qos), qos, null);
                 }
-                packet.PacketId = packetId;
+                packet.PacketId = packetId + 1;
             }
             using (Stream payloadStream = message.Payload)
             {

--- a/src/ProtocolGateway.IotHubClient/DeviceClientMessage.cs
+++ b/src/ProtocolGateway.IotHubClient/DeviceClientMessage.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.IotHubClient
 
         public uint DeliveryCount => this.message.DeliveryCount;
 
-        public ushort SequenceNumber => unchecked ((ushort)this.message.SequenceNumber);
+        public ulong SequenceNumber => this.message.SequenceNumber;
 
         public string MessageId
         {

--- a/src/ProtocolGateway.IotHubClient/IotHubClient.cs
+++ b/src/ProtocolGateway.IotHubClient/IotHubClient.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.IotHubClient
             try
             {
                 Message message = await this.deviceClient.ReceiveAsync(TimeSpan.MaxValue);
-                return new DeviceClientMessage(message);
+                return message == null ? null : new DeviceClientMessage(message);
             }
             catch (IotHubException ex)
             {

--- a/src/ProtocolGateway.Providers.CloudStorage/BlobSessionStatePersistenceProvider.cs
+++ b/src/ProtocolGateway.Providers.CloudStorage/BlobSessionStatePersistenceProvider.cs
@@ -131,6 +131,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage
                     ? AccessCondition.GenerateIfNoneMatchCondition("*") // create
                     : AccessCondition.GenerateIfMatchCondition(state.ETag); // update
                 await blob.UploadFromStreamAsync(memoryStream, accessCondition, null, null);
+                state.ETag = blob.Properties.ETag;
             }
         }
 

--- a/src/ProtocolGateway.Providers.CloudStorage/TableMessageDeliveryState.cs
+++ b/src/ProtocolGateway.Providers.CloudStorage/TableMessageDeliveryState.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage
         {
         }
 
-        public TableMessageDeliveryState(string messageId)
+        public TableMessageDeliveryState(ulong sequenceNumber)
         {
-            this.MessageId = messageId;
+            this.SequenceNumber = sequenceNumber;
             this.LastModified = DateTime.UtcNow;
         }
 
@@ -25,6 +25,6 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage
             set { this.Timestamp = value; }
         }
 
-        public string MessageId { get; set; }
+        public ulong SequenceNumber { get; set; }
     }
 }

--- a/src/ProtocolGateway.Providers.CloudStorage/TableQos2StatePersistenceProvider.cs
+++ b/src/ProtocolGateway.Providers.CloudStorage/TableQos2StatePersistenceProvider.cs
@@ -59,20 +59,19 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage
             }
         }
 
-        public IQos2MessageDeliveryState Create(string messageId)
+        public IQos2MessageDeliveryState Create(ulong sequenceNumber)
         {
-            return new TableMessageDeliveryState(messageId);
+            return new TableMessageDeliveryState(sequenceNumber);
         }
 
         public async Task<IQos2MessageDeliveryState> GetMessageAsync(IDeviceIdentity deviceIdentity, int packetId)
         {
-            TableQuery<TableMessageDeliveryState> query = this.table.CreateQuery<TableMessageDeliveryState>();
             string rowKey = CalculateRowKey(deviceIdentity.Id, packetId);
-            query.FilterString =
-                TableQuery.CombineFilters(
+            TableQuery<TableMessageDeliveryState> query = new TableQuery<TableMessageDeliveryState>()
+                .Where(TableQuery.CombineFilters(
                     TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, CalculatePartitionKey(rowKey)),
                     TableOperators.And,
-                    TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.Equal, rowKey));
+                    TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.Equal, rowKey)));
             return await this.ReadRowAsync(query, CancellationToken.None);
         }
 


### PR DESCRIPTION
…er, SequenceNumber -> Packet Id conversion

Motivation:
Fix issues with Azure Storage-based persistence providers and sequence number conversion logic

Modifications:
- Azure Table QoS 2 persistence provider uses proper query API to retrieve only relevant row
- QoS 2 persistence provider API is modified to work with SequenceNumber instead of MessageId
-Azure Blob session state persistence provider is modified to update ETag value on in-memory session state object to allow saving it later on without any issue.
- 14 least significant bits are used when converting SequenceNumber into PacketId
- SequenceNumber type is changed to ulong.

Result:
- QoS 2 works
- multiple SUBSCRIBE / UNSUBSCRIBE requests work within a single connection lifetime
- generated Packet Id  is conformant with MQTT spec