### PR TITLE
Qos2

### DIFF
--- a/host/ProtocolGateway.Host.Cloud.Service/ProtocolGateway.Host.Cloud.Service.csproj
+++ b/host/ProtocolGateway.Host.Cloud.Service/ProtocolGateway.Host.Cloud.Service.csproj
@@ -34,36 +34,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.4\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.4\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.4\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.4\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.4\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.4\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Amqp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.0.0\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.1.1\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.2\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.5\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -112,6 +112,10 @@
       <HintPath>..\..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Security.3.2.3.0\lib\net45\Mono.Security.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="MurmurHash, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ff7eff5eb27df7b9, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\murmurhash-signed.1.0.0\lib\net45\MurmurHash.dll</HintPath>
@@ -120,10 +124,18 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PCLCrypto, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PCLCrypto.1.0.86\lib\net40-Client\PCLCrypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Validation, Version=2.0.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Validation.2.0.6.15003\lib\portable-net40+sl50+win+wpa81+wp80+Xamarin.iOS10+MonoAndroid10+MonoTouch10\Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/host/ProtocolGateway.Host.Cloud.Service/packages.config
+++ b/host/ProtocolGateway.Host.Cloud.Service/packages.config
@@ -1,24 +1,27 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.4" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="2.0.1406.1" targetFramework="net451" />
-  <package id="Microsoft.Azure.Amqp" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.Client" version="1.0.2" targetFramework="net451" />
+  <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.Client" version="1.0.5" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
+  <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
   <package id="murmurhash-signed" version="1.0.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="PCLCrypto" version="1.0.86" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.2" targetFramework="net451" />
+  <package id="Validation" version="2.0.6.15003" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net451" />
 </packages>

--- a/host/ProtocolGateway.Host.Common/ProtocolGateway.Host.Common.csproj
+++ b/host/ProtocolGateway.Host.Common/ProtocolGateway.Host.Common.csproj
@@ -31,36 +31,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.4\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.4\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.4\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.4\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.4\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.4\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Amqp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.0.0\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.1.1\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.2\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.5\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -71,12 +71,24 @@
       <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.IotHubClient.1.0.1\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.IotHubClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Security.3.2.3.0\lib\net45\Mono.Security.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PCLCrypto, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PCLCrypto.1.0.86\lib\net40-Client\PCLCrypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="Validation, Version=2.0.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Validation.2.0.6.15003\lib\portable-net40+sl50+win+wpa81+wp80+Xamarin.iOS10+MonoAndroid10+MonoTouch10\Validation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bootstrapper.cs" />

--- a/host/ProtocolGateway.Host.Common/packages.config
+++ b/host/ProtocolGateway.Host.Common/packages.config
@@ -1,14 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.4" targetFramework="net451" />
-  <package id="Microsoft.Azure.Amqp" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.Client" version="1.0.2" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
+  <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.Client" version="1.0.5" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.ProtocolGateway.IotHubClient" version="1.0.1" targetFramework="net451" />
+  <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="PCLCrypto" version="1.0.86" targetFramework="net451" />
+  <package id="Validation" version="2.0.6.15003" targetFramework="net451" />
 </packages>

--- a/host/ProtocolGateway.Host.Console/ProtocolGateway.Host.Console.csproj
+++ b/host/ProtocolGateway.Host.Console/ProtocolGateway.Host.Console.csproj
@@ -35,28 +35,28 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.4\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.4\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.4\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.4\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.4\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.4\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/host/ProtocolGateway.Host.Console/packages.config
+++ b/host/ProtocolGateway.Host.Console/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net451" />
-  <package id="DotNetty.Buffers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.4" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.1" targetFramework="net451" />

--- a/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
+++ b/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
@@ -32,28 +32,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.4\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.4\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.4\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.4\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.4\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.4\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/ProtocolGateway.Core/packages.config
+++ b/src/ProtocolGateway.Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.4" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
 </packages>

--- a/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.csproj
+++ b/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.csproj
@@ -36,40 +36,56 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.4\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.4\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.4\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.4\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.4\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.2.3.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.3\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Amqp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.0.0\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.1.1\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.2\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.5\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Security.3.2.3.0\lib\net45\Mono.Security.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PCLCrypto, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PCLCrypto.1.0.86\lib\net40-Client\PCLCrypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="Validation, Version=2.0.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Validation.2.0.6.15003\lib\portable-net40+sl50+win+wpa81+wp80+Xamarin.iOS10+MonoAndroid10+MonoTouch10\Validation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs">

--- a/src/ProtocolGateway.IotHubClient/packages.config
+++ b/src/ProtocolGateway.IotHubClient/packages.config
@@ -1,11 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.4" targetFramework="net451" />
-  <package id="Microsoft.Azure.Amqp" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.Client" version="1.0.2" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.2.3" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
+  <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.Client" version="1.0.5" targetFramework="net451" />
+  <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="PCLCrypto" version="1.0.86" targetFramework="net451" />
+  <package id="Validation" version="2.0.6.15003" targetFramework="net451" />
 </packages>

--- a/src/ProtocolGateway.Providers.CloudStorage/ProtocolGateway.Providers.CloudStorage.csproj
+++ b/src/ProtocolGateway.Providers.CloudStorage/ProtocolGateway.Providers.CloudStorage.csproj
@@ -32,24 +32,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.4\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.4\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.4\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.4\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.4\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/ProtocolGateway.Providers.CloudStorage/TableMessageDeliveryState.cs
+++ b/src/ProtocolGateway.Providers.CloudStorage/TableMessageDeliveryState.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage
             set { this.Timestamp = value; }
         }
 
-        public ulong SequenceNumber { get; set; }
+        public ulong SequenceNumber
+        {
+            get { return unchecked((ulong)this.MessageNumber); }
+            set { this.MessageNumber = unchecked((long)value); }
+        }
+
+        public long MessageNumber { get; set; }
     }
 }

--- a/src/ProtocolGateway.Providers.CloudStorage/packages.config
+++ b/src/ProtocolGateway.Providers.CloudStorage/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.4" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />

--- a/test/ProtocolGateway.Tests.Load/ProtocolGateway.Tests.Load.csproj
+++ b/test/ProtocolGateway.Tests.Load/ProtocolGateway.Tests.Load.csproj
@@ -40,36 +40,36 @@
       <HintPath>..\..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Buffers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.4\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.4\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.4\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.4\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.4\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.4\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Amqp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.0.0\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.1.1\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.1.0.1\lib\net451\Microsoft.Azure.Devices.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.1.0.5\lib\net451\Microsoft.Azure.Devices.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/test/ProtocolGateway.Tests.Load/packages.config
+++ b/test/ProtocolGateway.Tests.Load/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net452" />
-  <package id="DotNetty.Buffers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.4" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
-  <package id="Microsoft.Azure.Amqp" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices" version="1.0.1" targetFramework="net451" />
+  <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices" version="1.0.5" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
 </packages>

--- a/test/ProtocolGateway.Tests/EndToEndTests.cs
+++ b/test/ProtocolGateway.Tests/EndToEndTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Tests
         string deviceId;
         string deviceSas;
         readonly X509Certificate2 tlsCertificate;
-        static readonly TimeSpan CommunicationTimeout = TimeSpan.FromMilliseconds(-1); //TimeSpan.FromSeconds(15);
+        static readonly TimeSpan CommunicationTimeout = TimeSpan.FromSeconds(15);
         static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(5); //TimeSpan.FromMinutes(1);
 
         public EndToEndTests(ITestOutputHelper output)
@@ -436,6 +436,11 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Tests
 
                 var pubRelQoS2Packet1 = Assert.IsAssignableFrom<PubRelPacket>(currentMessageFunc());
                 Assert.Equal(publishQoS2Packet1.PacketId, pubRelQoS2Packet1.PacketId);
+
+                yield return TestScenarioStep.ReadMore();
+
+                var pubRelQoS2Packet2 = Assert.IsAssignableFrom<PubRelPacket>(currentMessageFunc());
+                Assert.Equal(publishQoS2Packet2.PacketId, pubRelQoS2Packet2.PacketId);
 
                 yield return TestScenarioStep.Write(
                     false, // it is a final step and we do not expect response

--- a/test/ProtocolGateway.Tests/ProtocolGateway.Tests.csproj
+++ b/test/ProtocolGateway.Tests/ProtocolGateway.Tests.csproj
@@ -40,40 +40,40 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.4\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.4\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.4\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.4\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.4\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.4.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.4\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Amqp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.0.0\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Amqp.1.1.1\lib\net451\Microsoft.Azure.Amqp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.1.0.1\lib\net451\Microsoft.Azure.Devices.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.1.0.5\lib\net451\Microsoft.Azure.Devices.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.2\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.Client.1.0.5\lib\net45\Microsoft.Azure.Devices.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -92,12 +92,20 @@
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Security.3.2.3.0\lib\net45\Mono.Security.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PCLCrypto, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PCLCrypto.1.0.86\lib\net40-Client\PCLCrypto.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -111,6 +119,10 @@
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Validation, Version=2.0.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Validation.2.0.6.15003\lib\portable-net40+sl50+win+wpa81+wp80+Xamarin.iOS10+MonoAndroid10+MonoTouch10\Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/test/ProtocolGateway.Tests/app.config
+++ b/test/ProtocolGateway.Tests/app.config
@@ -33,6 +33,30 @@
         <assemblyIdentity name="Microsoft.WindowsAzure.ServiceRuntime" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Buffers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Common" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Codecs" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Codecs.Mqtt" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Transport" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Handlers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings configSource="appSettings.config.user" />

--- a/test/ProtocolGateway.Tests/packages.config
+++ b/test/ProtocolGateway.Tests/packages.config
@@ -1,21 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.4" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.4" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer" version="2.0.1406.1" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
-  <package id="Microsoft.Azure.Amqp" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices" version="1.0.1" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.Client" version="1.0.2" targetFramework="net451" />
+  <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices" version="1.0.5" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.Client" version="1.0.5" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
+  <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="PCLCrypto" version="1.0.86" targetFramework="net451" />
+  <package id="Validation" version="2.0.6.15003" targetFramework="net451" />
   <package id="WindowsAzure.ServiceBus" version="3.1.4" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />


### PR DESCRIPTION
QoS 2 fix. DotNetty upgrade

Motivation:

There are critical fixes in DotNetty that may affect protocol gateway
QoS2 storage does not store the message sequence number

Modifications:

DotNetty upgraded. 
QoS2 Storage entity changed. 

Result:

DotNetty upgraded. QoS2 messages do not start flow from the beginning in case of PUBREL delivery failure they proceed from sending PUBREC. 