### PR TITLE
Update DotNetty to a newer version.

### DIFF
--- a/host/ProtocolGateway.Host.Cloud.Service/ProtocolGateway.Host.Cloud.Service.csproj
+++ b/host/ProtocolGateway.Host.Cloud.Service/ProtocolGateway.Host.Cloud.Service.csproj
@@ -34,28 +34,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -67,11 +67,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.Core.1.0.1\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.Core.1.0.4\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.1.0.1\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.1.0.4\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/host/ProtocolGateway.Host.Cloud.Service/WorkerRole.cs
+++ b/host/ProtocolGateway.Host.Cloud.Service/WorkerRole.cs
@@ -94,8 +94,16 @@ namespace ProtocolGateway.Host.Cloud.Service
 
             X509Certificate2 tlsCertificate = GetTlsCertificate(settingsProvider.GetSetting("TlsCertificateThumbprint"),
                 StoreName.My, StoreLocation.LocalMachine);
-            
-            await bootstrapper.RunAsync(tlsCertificate, threadCount, cancellationToken);
+
+            try
+            {
+                await bootstrapper.RunAsync(tlsCertificate, threadCount, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError(ex.ToString());
+                throw;
+            }
             await bootstrapper.CloseCompletion;
         }
 

--- a/host/ProtocolGateway.Host.Cloud.Service/app.config
+++ b/host/ProtocolGateway.Host.Cloud.Service/app.config
@@ -5,13 +5,20 @@
   </configSections>
   <mqttTopicRouting configSource="mqttTopicRouting.config.user" />
   <system.diagnostics>
-    <trace>
-      <listeners>
-        <add type="Microsoft.WindowsAzure.Diagnostics.DiagnosticMonitorTraceListener, Microsoft.WindowsAzure.Diagnostics, Version=2.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" name="AzureDiagnostics">
-          <filter type="" />
-        </add>
-      </listeners>
-    </trace>
+    <sources>
+      <source name="mySource" switchName="sourceSwitch"
+         switchType="System.Diagnostics.SourceSwitch"  >
+        <listeners>
+          <add type="Microsoft.WindowsAzure.Diagnostics.DiagnosticMonitorTraceListener, Microsoft.WindowsAzure.Diagnostics, Version=2.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" name="AzureDiagnostics">
+            <filter type="" />
+          </add>
+          <remove name="Default" />
+        </listeners>
+      </source>
+    </sources>
+    <switches>
+      <add name="sourceSwitch" value="Warning" />
+    </switches>
   </system.diagnostics>
   <system.net>
     <settings>
@@ -70,6 +77,30 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Buffers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Common" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Codecs" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Codecs.Mqtt" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Transport" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Handlers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/host/ProtocolGateway.Host.Cloud.Service/packages.config
+++ b/host/ProtocolGateway.Host.Cloud.Service/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="2.0.1406.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.5" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.1" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage" version="1.0.1" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.4" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage" version="1.0.4" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />

--- a/host/ProtocolGateway.Host.Common/ProtocolGateway.Host.Common.csproj
+++ b/host/ProtocolGateway.Host.Common/ProtocolGateway.Host.Common.csproj
@@ -31,28 +31,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -64,11 +64,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.Core.1.0.1\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.Core.1.0.4\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.IotHubClient, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.IotHubClient.1.0.1\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.IotHubClient.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.IotHubClient.1.0.4\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.IotHubClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">

--- a/host/ProtocolGateway.Host.Common/packages.config
+++ b/host/ProtocolGateway.Host.Common/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.5" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.1" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway.IotHubClient" version="1.0.1" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.4" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway.IotHubClient" version="1.0.4" targetFramework="net451" />
   <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="PCLCrypto" version="1.0.86" targetFramework="net451" />

--- a/host/ProtocolGateway.Host.Console/ProtocolGateway.Host.Console.csproj
+++ b/host/ProtocolGateway.Host.Console/ProtocolGateway.Host.Console.csproj
@@ -35,36 +35,36 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.Core.1.0.1\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.Core.1.0.4\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.1.0.1\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.1.0.4\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/host/ProtocolGateway.Host.Console/packages.config
+++ b/host/ProtocolGateway.Host.Console/packages.config
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net451" />
-  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.1" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage" version="1.0.1" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.4" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage" version="1.0.4" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />

--- a/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
+++ b/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
@@ -32,28 +32,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/ProtocolGateway.Core/ProtocolGateway.Core.nuspec
+++ b/src/ProtocolGateway.Core/ProtocolGateway.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Devices.ProtocolGateway.Core</id>
-    <version>1.0.2</version>
+    <version>1.0.4</version>
     <title>Microsoft Azure IoT protocol gateway framework - Core</title>
     <authors>Microsoft Azure</authors>
     <owners>Microsoft Azure</owners>
@@ -12,8 +12,8 @@
     <language>en-US</language>
     <dependencies>
       <group targetFramework="net451">
-        <dependency id="DotNetty.Codecs.Mqtt-signed" version="0.2.4" />
-        <dependency id="DotNetty.Handlers-signed" version="0.2.4" />
+        <dependency id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" />
+        <dependency id="DotNetty.Handlers-signed" version="0.3.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/ProtocolGateway.Core/packages.config
+++ b/src/ProtocolGateway.Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
 </packages>

--- a/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.csproj
+++ b/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.csproj
@@ -36,28 +36,28 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.3.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.2.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.nuspec
+++ b/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Devices.ProtocolGateway.IotHubClient</id>
-    <version>1.0.2</version>
+    <version>1.0.4</version>
     <title>Microsoft Azure IoT protocol gateway framework - IoT Hub client</title>
     <authors>Microsoft Azure</authors>
     <owners>Microsoft Azure</owners>
@@ -12,8 +12,8 @@
     <language>en-US</language>
     <dependencies>
       <group targetFramework="net451">
-        <dependency id="Microsoft.Azure.Devices.Client" version="1.0.2" />
-        <dependency id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.2" />
+        <dependency id="Microsoft.Azure.Devices.Client" version="1.0.4" />
+        <dependency id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.4" />
       </group>
     </dependencies>
   </metadata>

--- a/src/ProtocolGateway.IotHubClient/packages.config
+++ b/src/ProtocolGateway.IotHubClient/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.3" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.5" targetFramework="net451" />
   <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />

--- a/src/ProtocolGateway.Providers.CloudStorage/ProtocolGateway.Providers.CloudStorage.csproj
+++ b/src/ProtocolGateway.Providers.CloudStorage/ProtocolGateway.Providers.CloudStorage.csproj
@@ -32,24 +32,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/ProtocolGateway.Providers.CloudStorage/ProtocolGateway.Providers.CloudStorage.nuspec
+++ b/src/ProtocolGateway.Providers.CloudStorage/ProtocolGateway.Providers.CloudStorage.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage</id>
-    <version>1.0.2</version>
+    <version>1.0.4</version>
     <title>Microsoft Azure IoT protocol gateway framework - Azure Storage persistence providers</title>
     <authors>Microsoft Azure</authors>
     <owners>Microsoft Azure</owners>
@@ -12,8 +12,8 @@
     <language>en-US</language>
     <dependencies>
       <group targetFramework="net451">
-        <dependency id="DotNetty.Codecs.Mqtt-signed" version="0.2.4" />
-        <dependency id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.2" />
+        <dependency id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" />
+        <dependency id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.4" />
         <dependency id="WindowsAzure.Storage" version="4.3.0" />
         <dependency id="Newtonsoft.Json" version="6.0.8" />
         <dependency id="murmurhash-signed" version="1.0.0" />

--- a/src/ProtocolGateway.Providers.CloudStorage/TableMessageDeliveryState.cs
+++ b/src/ProtocolGateway.Providers.CloudStorage/TableMessageDeliveryState.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage
 
         public TableMessageDeliveryState(ulong sequenceNumber)
         {
-            this.SequenceNumber = sequenceNumber;
+            this.MessageNumber = unchecked ((long)sequenceNumber);
             this.LastModified = DateTime.UtcNow;
         }
 
@@ -25,12 +25,8 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage
             set { this.Timestamp = value; }
         }
 
-        public ulong SequenceNumber
-        {
-            get { return unchecked((ulong)this.MessageNumber); }
-            set { this.MessageNumber = unchecked((long)value); }
-        }
-
         public long MessageNumber { get; set; }
+
+        ulong IQos2MessageDeliveryState.SequenceNumber => unchecked((ulong)this.MessageNumber);
     }
 }

--- a/src/ProtocolGateway.Providers.CloudStorage/packages.config
+++ b/src/ProtocolGateway.Providers.CloudStorage/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />

--- a/test/ProtocolGateway.Tests.Load/ProtocolGateway.Tests.Load.csproj
+++ b/test/ProtocolGateway.Tests.Load/ProtocolGateway.Tests.Load.csproj
@@ -40,28 +40,28 @@
       <HintPath>$(SolutionDir)\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/ProtocolGateway.Tests.Load/packages.config
+++ b/test/ProtocolGateway.Tests.Load/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net452" />
-  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />

--- a/test/ProtocolGateway.Tests/ProtocolGateway.Tests.csproj
+++ b/test/ProtocolGateway.Tests/ProtocolGateway.Tests.csproj
@@ -40,28 +40,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.2.5\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.2.5\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.2.5\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.2.5\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.2.5\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.2.5.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.2.5\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/ProtocolGateway.Tests/app.config
+++ b/test/ProtocolGateway.Tests/app.config
@@ -35,27 +35,27 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Buffers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Common" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs.Mqtt" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Transport" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Handlers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.2.4.0" newVersion="0.2.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/ProtocolGateway.Tests/packages.config
+++ b/test/ProtocolGateway.Tests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.2.5" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.2.5" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer" version="2.0.1406.1" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />


### PR DESCRIPTION
Motivation:

Some dotnetty dll references were broken

Modifications:

References got fixed. DotNetty packages were updated to the latest version.

Result:

PG host can be assembled and deployed without any issues. We've got critical fixes and improvements of DotNetty