### PR TITLE
Fixes AMQP transport settings

### DIFF
--- a/host/ProtocolGateway.Host.Common/ProtocolGateway.Host.Common.csproj
+++ b/host/ProtocolGateway.Host.Common/ProtocolGateway.Host.Common.csproj
@@ -68,7 +68,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.IotHubClient, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.IotHubClient.1.0.5\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.IotHubClient.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.Devices.ProtocolGateway.IotHubClient.1.0.6\lib\net451\Microsoft.Azure.Devices.ProtocolGateway.IotHubClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">

--- a/host/ProtocolGateway.Host.Common/packages.config
+++ b/host/ProtocolGateway.Host.Common/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.7" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.4" targetFramework="net451" />
-  <package id="Microsoft.Azure.Devices.ProtocolGateway.IotHubClient" version="1.0.5" targetFramework="net451" />
+  <package id="Microsoft.Azure.Devices.ProtocolGateway.IotHubClient" version="1.0.6" targetFramework="net451" />
   <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="PCLCrypto" version="1.0.86" targetFramework="net451" />

--- a/src/ProtocolGateway.IotHubClient/IotHubClient.cs
+++ b/src/ProtocolGateway.IotHubClient/IotHubClient.cs
@@ -34,7 +34,11 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.IotHubClient
                 }
                 var transportSettings = new ITransportSettings[]
                 {
-                    new AmqpTransportSettings(TransportType.Amqp)
+                    new AmqpTransportSettings(TransportType.Amqp_Tcp_Only)
+                    {
+                        AmqpConnectionPoolSettings = amqpConnectionPoolSettings
+                    },
+                    new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
                     {
                         AmqpConnectionPoolSettings = amqpConnectionPoolSettings
                     }

--- a/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.nuspec
+++ b/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Devices.ProtocolGateway.IotHubClient</id>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <title>Microsoft Azure IoT protocol gateway framework - IoT Hub client</title>
     <authors>Microsoft Azure</authors>
     <owners>Microsoft Azure</owners>


### PR DESCRIPTION
Motivation:

AMQP transport settings does not allow to provide the general AMQP transport type

Modifications:
It provides two separate transport settings for TCP and WebSocets

Results:
Bug fixed