### PR TITLE
Upgrading to DotNetty 0.3.1

### DIFF
--- a/host/ProtocolGateway.Host.Cloud.Service/ProtocolGateway.Host.Cloud.Service.csproj
+++ b/host/ProtocolGateway.Host.Cloud.Service/ProtocolGateway.Host.Cloud.Service.csproj
@@ -34,28 +34,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.3.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.3.1\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.3.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.3.1\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.3.1\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.3.1\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/host/ProtocolGateway.Host.Cloud.Service/app.config
+++ b/host/ProtocolGateway.Host.Cloud.Service/app.config
@@ -87,7 +87,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs.Mqtt" publicKeyToken="e7a0210a354f294a" culture="neutral" />

--- a/host/ProtocolGateway.Host.Cloud.Service/app.config
+++ b/host/ProtocolGateway.Host.Cloud.Service/app.config
@@ -6,8 +6,7 @@
   <mqttTopicRouting configSource="mqttTopicRouting.config.user" />
   <system.diagnostics>
     <sources>
-      <source name="mySource" switchName="sourceSwitch"
-         switchType="System.Diagnostics.SourceSwitch"  >
+      <source name="mySource" switchName="sourceSwitch" switchType="System.Diagnostics.SourceSwitch">
         <listeners>
           <add type="Microsoft.WindowsAzure.Diagnostics.DiagnosticMonitorTraceListener, Microsoft.WindowsAzure.Diagnostics, Version=2.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" name="AzureDiagnostics">
             <filter type="" />
@@ -80,11 +79,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Buffers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Common" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs" publicKeyToken="e7a0210a354f294a" culture="neutral" />
@@ -92,15 +91,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs.Mqtt" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Transport" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Handlers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/host/ProtocolGateway.Host.Cloud.Service/packages.config
+++ b/host/ProtocolGateway.Host.Cloud.Service/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="2.0.1406.1" targetFramework="net451" />

--- a/host/ProtocolGateway.Host.Common/ProtocolGateway.Host.Common.csproj
+++ b/host/ProtocolGateway.Host.Common/ProtocolGateway.Host.Common.csproj
@@ -31,28 +31,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.3.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.3.1\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.3.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.3.1\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.3.1\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.3.1\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -97,7 +97,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/host/ProtocolGateway.Host.Common/packages.config
+++ b/host/ProtocolGateway.Host.Common/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.7" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.4" targetFramework="net451" />

--- a/host/ProtocolGateway.Host.Console/App.config
+++ b/host/ProtocolGateway.Host.Console/App.config
@@ -45,6 +45,10 @@
         <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Codecs" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs.Mqtt" publicKeyToken="e7a0210a354f294a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>

--- a/host/ProtocolGateway.Host.Console/App.config
+++ b/host/ProtocolGateway.Host.Console/App.config
@@ -40,6 +40,26 @@
         <assemblyIdentity name="Microsoft.WindowsAzure.ServiceRuntime" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Transport" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Codecs.Mqtt" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Common" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Buffers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Handlers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/host/ProtocolGateway.Host.Console/ProtocolGateway.Host.Console.csproj
+++ b/host/ProtocolGateway.Host.Console/ProtocolGateway.Host.Console.csproj
@@ -35,28 +35,28 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers-signed.0.3.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs-signed.0.3.1\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.Mqtt-signed.0.3.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common-signed.0.3.1\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers-signed.0.3.1\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport-signed.0.3.1\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Devices.ProtocolGateway.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/host/ProtocolGateway.Host.Console/packages.config
+++ b/host/ProtocolGateway.Host.Console/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net451" />
-  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.ProtocolGateway.Core" version="1.0.4" targetFramework="net451" />

--- a/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
+++ b/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
@@ -32,28 +32,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.1\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.1\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.1\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.1\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/ProtocolGateway.Core/packages.config
+++ b/src/ProtocolGateway.Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.1" targetFramework="net451" />
 </packages>

--- a/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.csproj
+++ b/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.csproj
@@ -36,28 +36,28 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.1\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.1\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.1\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.1\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/ProtocolGateway.IotHubClient/packages.config
+++ b/src/ProtocolGateway.IotHubClient/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Azure.Devices.Client" version="1.0.7" targetFramework="net451" />
   <package id="Mono.Security" version="3.2.3.0" targetFramework="net451" />

--- a/src/ProtocolGateway.Providers.CloudStorage/ProtocolGateway.Providers.CloudStorage.csproj
+++ b/src/ProtocolGateway.Providers.CloudStorage/ProtocolGateway.Providers.CloudStorage.csproj
@@ -32,24 +32,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.1\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.1\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.1\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/ProtocolGateway.Providers.CloudStorage/packages.config
+++ b/src/ProtocolGateway.Providers.CloudStorage/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.1" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net451" />

--- a/test/ProtocolGateway.Tests.Load/App.config
+++ b/test/ProtocolGateway.Tests.Load/App.config
@@ -38,6 +38,10 @@
         <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Codecs" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs.Mqtt" publicKeyToken="e7a0210a354f294a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>

--- a/test/ProtocolGateway.Tests.Load/App.config
+++ b/test/ProtocolGateway.Tests.Load/App.config
@@ -33,6 +33,26 @@
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Transport" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Codecs.Mqtt" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Common" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Buffers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DotNetty.Handlers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/ProtocolGateway.Tests.Load/ProtocolGateway.Tests.Load.csproj
+++ b/test/ProtocolGateway.Tests.Load/ProtocolGateway.Tests.Load.csproj
@@ -40,28 +40,28 @@
       <HintPath>$(SolutionDir)\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.1\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.1\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.1\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.1\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/ProtocolGateway.Tests.Load/packages.config
+++ b/test/ProtocolGateway.Tests.Load/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net452" />
-  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.1" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.Azure.Amqp" version="1.1.1" targetFramework="net451" />

--- a/test/ProtocolGateway.Tests/ProtocolGateway.Tests.csproj
+++ b/test/ProtocolGateway.Tests/ProtocolGateway.Tests.csproj
@@ -40,28 +40,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.0\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.1\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.0\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.1\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.0\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.0\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.1\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.0\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.1\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.3.0.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.0\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.1\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Amqp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/ProtocolGateway.Tests/app.config
+++ b/test/ProtocolGateway.Tests/app.config
@@ -35,11 +35,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Buffers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Common" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs" publicKeyToken="e7a0210a354f294a" culture="neutral" />
@@ -47,15 +47,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs.Mqtt" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Transport" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Handlers" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/ProtocolGateway.Tests/app.config
+++ b/test/ProtocolGateway.Tests/app.config
@@ -43,7 +43,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs" publicKeyToken="e7a0210a354f294a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.3.0.0" newVersion="0.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.3.1.0" newVersion="0.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetty.Codecs.Mqtt" publicKeyToken="e7a0210a354f294a" culture="neutral" />

--- a/test/ProtocolGateway.Tests/packages.config
+++ b/test/ProtocolGateway.Tests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Codecs-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Common-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Handlers-signed" version="0.3.0" targetFramework="net451" />
-  <package id="DotNetty.Transport-signed" version="0.3.0" targetFramework="net451" />
+  <package id="DotNetty.Buffers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs.Mqtt-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Codecs-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Common-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Handlers-signed" version="0.3.1" targetFramework="net451" />
+  <package id="DotNetty.Transport-signed" version="0.3.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net451" />
   <package id="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer" version="2.0.1406.1" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />


### PR DESCRIPTION
Motivation:
DotNetty 0.3.1 brings important fixes and optimizations in TlsHandler.

Modifications:
- DotNetty NuGet packages are updated to 0.3.1

Result:
Protocol Gateway is better positioned to work with TLS-enabled clients.