### PR TITLE
Allows to use unsigned dotnetty assemblies based on configuration

### DIFF
--- a/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
+++ b/src/ProtocolGateway.Core/ProtocolGateway.Core.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), External.props))\External.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), External.props))\External.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -31,31 +32,65 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <Choose>
+    <When Condition="'$(DotNettyPath)' == ''">
+      <ItemGroup>
+        <Reference Include="DotNetty.Buffers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+          <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.1\lib\net45\DotNetty.Buffers.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="DotNetty.Codecs, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+          <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.1\lib\net45\DotNetty.Codecs.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+          <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="DotNetty.Common, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+          <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.1\lib\net45\DotNetty.Common.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="DotNetty.Handlers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+          <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.1\lib\net45\DotNetty.Handlers.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="DotNetty.Transport, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
+          <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.1\lib\net45\DotNetty.Transport.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <ProjectReference Include="$(DotNettyPath)\src\DotNetty.Buffers\DotNetty.Buffers.csproj">
+          <Project>{5de3c557-48bf-4cdb-9f47-474d343dd841}</Project>
+          <Name>DotNetty.Buffers</Name>
+        </ProjectReference>
+        <ProjectReference Include="$(DotNettyPath)\src\DotNetty.Codecs.Mqtt\DotNetty.Codecs.Mqtt.csproj">
+          <Project>{58ffea83-c956-49f9-9435-18332ad0e0d1}</Project>
+          <Name>DotNetty.Codecs.Mqtt</Name>
+        </ProjectReference>
+        <ProjectReference Include="$(DotNettyPath)\src\DotNetty.Codecs\DotNetty.Codecs.csproj">
+          <Project>{2abd244e-ef8f-460d-9c30-39116499e6e4}</Project>
+          <Name>DotNetty.Codecs</Name>
+        </ProjectReference>
+        <ProjectReference Include="$(DotNettyPath)\src\DotNetty.Common\DotNetty.Common.csproj">
+          <Project>{de58fe41-5e99-44e5-86bc-fc9ed8761daf}</Project>
+          <Name>DotNetty.Common</Name>
+        </ProjectReference>
+        <ProjectReference Include="$(DotNettyPath)\src\DotNetty.Handlers\DotNetty.Handlers.csproj">
+          <Project>{09628314-f44e-445e-9f0d-cbe33b736ac3}</Project>
+          <Name>DotNetty.Handlers</Name>
+        </ProjectReference>
+        <ProjectReference Include="$(DotNettyPath)\src\DotNetty.Transport\DotNetty.Transport.csproj">
+          <Project>{8218c9ee-0a4a-432f-a12a-b54202f97b05}</Project>
+          <Name>DotNetty.Transport</Name>
+        </ProjectReference>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Buffers-signed.0.3.1\lib\net45\DotNetty.Buffers.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs-signed.0.3.1\lib\net45\DotNetty.Codecs.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="DotNetty.Codecs.Mqtt, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Codecs.Mqtt-signed.0.3.1\lib\net45\DotNetty.Codecs.Mqtt.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="DotNetty.Common, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Common-signed.0.3.1\lib\net45\DotNetty.Common.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Handlers-signed.0.3.1\lib\net45\DotNetty.Handlers.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.3.1.0, Culture=neutral, PublicKeyToken=e7a0210a354f294a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\DotNetty.Transport-signed.0.3.1\lib\net45\DotNetty.Transport.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Motivation:

Using signed dotnetty does not allow to bring the dotnetty as a submodule and there fore release cadence of dependent projects gets longer

Modifications:
The project file has two option to reference the DotNetty projects directly instead of the nuget package if you provide settings in the external properties file

Results:
Project can reference in with either signed or not signed Dotnetty based on config