### PR TITLE
Switching off MQTT retransmission by default

### DIFF
--- a/host/ProtocolGateway.Host.Cloud/ServiceConfiguration.Cloud.cscfg
+++ b/host/ProtocolGateway.Host.Cloud/ServiceConfiguration.Cloud.cscfg
@@ -4,7 +4,7 @@
     <Instances count="2" />
     <ConfigurationSettings>
       <Setting name="MaxPendingInboundAcknowledgements" value="10" />
-      <Setting name="DeviceReceiveAckTimeout" value="00:01:00" />
+      <Setting name="DeviceReceiveAckTimeout" value="00:00:00" />
       <Setting name="MaxInboundMessageSize" value="262144" />
       <Setting name="ConnectArrivalTimeout" value="00:01:00" />
       <Setting name="MaxKeepAliveTimeout" value="00:10:00" />

--- a/host/ProtocolGateway.Host.Cloud/ServiceConfiguration.Local.cscfg
+++ b/host/ProtocolGateway.Host.Cloud/ServiceConfiguration.Local.cscfg
@@ -4,7 +4,7 @@
     <Instances count="1" />
     <ConfigurationSettings>
       <Setting name="MaxPendingInboundAcknowledgements" value="10" />
-      <Setting name="DeviceReceiveAckTimeout" value="00:01:00" />
+      <Setting name="DeviceReceiveAckTimeout" value="00:00:00" />
       <Setting name="MaxInboundMessageSize" value="262144" />
       <Setting name="ConnectArrivalTimeout" value="00:01:00" />
       <Setting name="MaxKeepAliveTimeout" value="00:10:00" />

--- a/host/ProtocolGateway.Host.Console/appSettings.config.user
+++ b/host/ProtocolGateway.Host.Console/appSettings.config.user
@@ -1,7 +1,7 @@
 <appSettings>
   <!-- general protocol gateway settings -->
   <add key="MaxPendingInboundAcknowledgements" value="16" /> <!-- default: 16 -->
-  <add key="DeviceReceiveAckTimeout" value="00:01:00" /> <!-- default: no timeout -->
+  <add key="DeviceReceiveAckTimeout" value="00:00:00" /> <!-- default: no timeout -->
   <add key="MaxInboundMessageSize" value="262144" /> <!-- 256KB -->
   <add key="ConnectArrivalTimeout" value="00:01:00" /> <!-- default: no timeout -->
   <add key="MaxKeepAliveTimeout" value="00:10:00" /> <!-- default: no limit -->

--- a/test/ProtocolGateway.Tests/appSettings.config.user
+++ b/test/ProtocolGateway.Tests/appSettings.config.user
@@ -14,7 +14,7 @@
 
   <!-- Protocol Gateway settings -->
   <add key="MaxPendingInboundAcknowledgements" value="16" />
-  <add key="DeviceReceiveAckTimeout" value="00:01:00" />
+  <add key="DeviceReceiveAckTimeout" value="00:00:00" />
   <add key="MaxInboundMessageSize" value="262144" />
   <add key="ConnectArrivalTimeout" value="00:01:00" />
   <add key="MaxKeepAliveTimeout" value="00:10:00" />


### PR DESCRIPTION
Motivation:
Having retransmission ON and more than 1 in-flight outbound message is not allowed now causing process to fail on initialization.

Modifications:
- switched off retransmission by default in all host & test configurations

Result:
Hosts work OOTB as expected.