### PR TITLE
Tracks Channel ID

### DIFF
--- a/src/ProtocolGateway.Core/Instrumentation/CommonEventSource.cs
+++ b/src/ProtocolGateway.Core/Instrumentation/CommonEventSource.cs
@@ -30,25 +30,28 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Instrumentation
 
         public bool IsErrorEnabled => this.IsEnabled(EventLevel.Error, EventKeywords.None);
 
+        [NonEvent]
+        public void Verbose(string message, string info) => this.Verbose(message, info, string.Empty);
+
         [Event(VerboseEventId, Level = EventLevel.Verbose)]
-        public void Verbose(string message, string info) => this.WriteEvent(VerboseEventId, message, info);
+        public void Verbose(string message, string info, string scope) => this.WriteEvent(VerboseEventId, message, info, scope);
 
         [Event(InfoEventId, Level = EventLevel.Informational)]
-        public void Info(string message, string info) => this.WriteEvent(InfoEventId, message, info);
+        public void Info(string message, string info, string scope) => this.WriteEvent(InfoEventId, message, info, scope);
 
         [NonEvent]
-        public void Warning(string message) => this.Warning(message, string.Empty);
+        public void Warning(string message, string scope) => this.Warning(message, string.Empty, scope);
 
         [NonEvent]
-        public void Warning(string message, Exception exception) => this.Warning(message, exception?.ToString() ?? string.Empty);
+        public void Warning(string message, Exception exception, string scope) => this.Warning(message, exception?.ToString() ?? string.Empty, scope);
 
         [Event(WarningEventId, Level = EventLevel.Warning)]
-        public void Warning(string message, string exception) => this.WriteEvent(WarningEventId, message, exception);
+        public void Warning(string message, string exception, string scope) => this.WriteEvent(WarningEventId, message, exception, scope);
 
         [NonEvent]
-        public void Error(string message, Exception exception) => this.Error(message, exception?.ToString() ?? string.Empty);
+        public void Error(string message, Exception exception, string scope) => this.Error(message, exception?.ToString() ?? string.Empty, scope);
 
         [Event(ErrorEventId, Level = EventLevel.Error)]
-        public void Error(string message, string exception) => this.WriteEvent(ErrorEventId, message, exception);
+        public void Error(string message, string exception, string scope) => this.WriteEvent(ErrorEventId, message, exception, scope);
     }
 }

--- a/src/ProtocolGateway.Core/Messaging/SingleClientMessagingBridge.cs
+++ b/src/ProtocolGateway.Core/Messaging/SingleClientMessagingBridge.cs
@@ -43,12 +43,13 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Messaging
         {
             if (cause == null)
             {
-                CommonEventSource.Log.Info($"Closing connection for device: {this.deviceIdentity}", string.Empty);
+                CommonEventSource.Log.Info($"Closing connection for device: {this.deviceIdentity}", string.Empty, string.Empty);
             }
             else
             {
-                string scope = cause.Data[MqttAdapter.ScopeExceptionDataKey]?.ToString();
-                CommonEventSource.Log.Warning($"Closing connection for device: {this.deviceIdentity}" + (scope == null ? null : ", scope: " + scope), cause);
+                string operationScope = cause.Data[MqttAdapter.OperationScopeExceptionDataKey]?.ToString();
+                string connectionScope = cause.Data[MqttAdapter.ConnectionScopeExceptionDataKey]?.ToString();
+                CommonEventSource.Log.Warning($"Closing connection for device: {this.deviceIdentity}" + (operationScope == null ? null : ", scope: " + operationScope), cause, connectionScope);
             }
 
             if (this.messagingChannel != null)

--- a/src/ProtocolGateway.Core/Mqtt/MessageAsyncProcessor.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MessageAsyncProcessor.cs
@@ -11,12 +11,13 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
     {
         readonly Func<IChannelHandlerContext, T, Task> processFunc;
 
-        public MessageAsyncProcessor(Func<IChannelHandlerContext, T, Task> processFunc)
+        public MessageAsyncProcessor(Func<IChannelHandlerContext, T, Task> processFunc, string scope)
+            : base(scope)
         {
             this.processFunc = processFunc;
         }
 
-        protected override Task ProcessAsync(IChannelHandlerContext context, T packet)
+        protected override Task ProcessAsync(IChannelHandlerContext context, T packet, string scope)
         {
             return this.processFunc(context, packet);
         }

--- a/src/ProtocolGateway.Core/Mqtt/MessageAsyncProcessorBase.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MessageAsyncProcessorBase.cs
@@ -12,12 +12,14 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
 
     public abstract class MessageAsyncProcessorBase<T>
     {
+        readonly string scope;
         readonly Queue<T> backlogQueue;
         State state;
         readonly TaskCompletionSource completionSource;
 
-        protected MessageAsyncProcessorBase()
+        protected MessageAsyncProcessorBase(string scope)
         {
+            this.scope = scope;
             this.backlogQueue = new Queue<T>();
             this.completionSource = new TaskCompletionSource();
         }
@@ -102,7 +104,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                 while (queue.Count > 0 && this.state != State.Aborted)
                 {
                     T message = queue.Dequeue();
-                    await this.ProcessAsync(context, message);
+                    await this.ProcessAsync(context, message, this.scope);
                 }
 
                 switch (this.state)
@@ -125,7 +127,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             }
         }
 
-        protected abstract Task ProcessAsync(IChannelHandlerContext context, T packet);
+        protected abstract Task ProcessAsync(IChannelHandlerContext context, T packet, string scope);
 
         enum State
         {

--- a/src/ProtocolGateway.Core/Mqtt/Util.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Util.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             return topicFilterIndex == topicFilter.Length && topicNameIndex == topicName.Length;
         }
 
-        public static QualityOfService DeriveQos(IMessage message, Settings config)
+        public static QualityOfService DeriveQos(IMessage message, Settings config, string scope)
         {
             string qosValue;
             if (!message.Properties.TryGetValue(config.QoSPropertyName, out qosValue))
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
 
             if (qosValue.Length > 1)
             {
-                CommonEventSource.Log.Warning($"Message defined QoS '{qosValue}' is not supported. Downgrading to default value of '{config.DefaultPublishToClientQoS}'");
+                CommonEventSource.Log.Warning($"Message defined QoS '{qosValue}' is not supported. Downgrading to default value of '{config.DefaultPublishToClientQoS}'", scope);
                 return config.DefaultPublishToClientQoS;
             }
 
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                 case '2':
                     return QualityOfService.ExactlyOnce;
                 default:
-                    CommonEventSource.Log.Warning($"Message defined QoS '{qosValue}' is not supported. Downgrading to default value of '{config.DefaultPublishToClientQoS}'");
+                    CommonEventSource.Log.Warning($"Message defined QoS '{qosValue}' is not supported. Downgrading to default value of '{config.DefaultPublishToClientQoS}'", scope);
                     return config.DefaultPublishToClientQoS;
             }
         }

--- a/src/ProtocolGateway.IotHubClient/IotHubDeviceIdentity.cs
+++ b/src/ProtocolGateway.IotHubClient/IotHubDeviceIdentity.cs
@@ -7,6 +7,10 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.IotHubClient
 
     public sealed class IotHubDeviceIdentity : IDeviceIdentity
     {
+        string asString;
+        string policyName;
+        AuthenticationScope scope;
+
         public IotHubDeviceIdentity(string iotHubHostName, string deviceId)
         {
             this.IotHubHostName = iotHubHostName;
@@ -17,13 +21,29 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.IotHubClient
 
         public bool IsAuthenticated => true;
 
-        public string IotHubHostName { get; private set; }
+        public string IotHubHostName { get; }
 
-        public string PolicyName { get; private set; }
+        public string PolicyName
+        {
+            get { return this.policyName; }
+            private set
+            {
+                this.policyName = value;
+                this.asString = null;
+            }
+        }
 
         public string Secret { get; private set; }
 
-        public AuthenticationScope Scope { get; private set; }
+        public AuthenticationScope Scope
+        {
+            get { return this.scope; }
+            private set
+            {
+                this.scope = value;
+                this.asString = null;
+            }
+        }
 
         public static bool TryParse(string value, out IotHubDeviceIdentity identity)
         {
@@ -54,6 +74,16 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.IotHubClient
         {
             this.Scope = AuthenticationScope.DeviceKey;
             this.Secret = keyValue;
+        }
+
+        public override string ToString()
+        {
+            if (this.asString == null)
+            {
+                string policy = string.IsNullOrEmpty(this.PolicyName) ? "<none>" : this.PolicyName;
+                this.asString = $"{this.Id} [IotHubHostName: {this.IotHubHostName}; PolicyName: {policy}; Scope: {this.Scope}]";
+            }
+            return this.asString;
         }
     }
 }


### PR DESCRIPTION
Motivation:
During investigation it is impossible to distinguish events sent by one client
from event sent by another client

Modifications:
Every event traces channel ID as a new column in ETW events

Results:
All events that happen during activity of one client have unique distinguisher
-  the channel ID, that can be used for the purpose described above.
We also trace event that matches channel ID with device ID so that users could
easily filter events made by a specific client.