### PR TITLE
Added subscription creation time check threshold 

### DIFF
--- a/host/ProtocolGateway.Host.Cloud/ServiceConfiguration.Cloud.cscfg
+++ b/host/ProtocolGateway.Host.Cloud/ServiceConfiguration.Cloud.cscfg
@@ -11,6 +11,7 @@
       <Setting name="RetainPropertyName" value="mqtt-retain" />
       <Setting name="DupPropertyName" value="mqtt-dup" />
       <Setting name="QoSPropertyName" value="mqtt-qos" />
+      <Setting name="SubscriptionCreationTimeCheckThreshold" value="00:00:30"/>
       <Setting name="IotHubClient.ConnectionString" value="[parameters('iotHubConnectionString')]" />
       <Setting name="IotHubClient.MaxPendingInboundMessages" value="10" />
       <Setting name="IotHubClient.MaxPendingOutboundMessages" value="10" />

--- a/host/ProtocolGateway.Host.Cloud/ServiceConfiguration.Local.cscfg
+++ b/host/ProtocolGateway.Host.Cloud/ServiceConfiguration.Local.cscfg
@@ -11,6 +11,7 @@
       <Setting name="RetainPropertyName" value="mqtt-retain" />
       <Setting name="DupPropertyName" value="mqtt-dup" />
       <Setting name="QoSPropertyName" value="mqtt-qos" />
+      <Setting name="SubscriptionCreationTimeCheckThreshold" value="00:00:30"/>
       <Setting name="IotHubClient.ConnectionString" value="TODO: IoT Hub connection string to connect to" />
       <Setting name="IotHubClient.MaxPendingInboundMessages" value="10" />
       <Setting name="IotHubClient.MaxPendingOutboundMessages" value="10" />

--- a/host/ProtocolGateway.Host.Cloud/ServiceDefinition.csdef
+++ b/host/ProtocolGateway.Host.Cloud/ServiceDefinition.csdef
@@ -10,6 +10,7 @@
       <Setting name="RetainPropertyName" />
       <Setting name="DupPropertyName" />
       <Setting name="QoSPropertyName" />
+      <Setting name="SubscriptionCreationTimeCheckThreshold" />
       <Setting name="IotHubClient.ConnectionString" />
       <Setting name="IotHubClient.MaxPendingInboundMessages" />
       <Setting name="IotHubClient.MaxPendingOutboundMessages" />

--- a/src/ProtocolGateway.Core/Mqtt/MqttAdapter.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MqttAdapter.cs
@@ -721,11 +721,12 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             bool found = false;
             qos = QualityOfService.AtMostOnce;
             IReadOnlyList<ISubscription> subscriptions = this.sessionState.Subscriptions;
+            TimeSpan threshold = this.settings.SubscriptionCreationTimeCheckThreshold ?? TimeSpan.Zero; 
             for (int i = 0; i < subscriptions.Count; i++)
             {
                 ISubscription subscription = subscriptions[i];
                 if ((!found || subscription.QualityOfService > qos)
-                    && subscription.CreationTime < messageTime
+                    && (subscription.CreationTime < messageTime || subscription.CreationTime.Subtract(messageTime) <= threshold)
                     && Util.CheckTopicFilterMatch(topicName, subscription.TopicFilter))
                 {
                     found = true;

--- a/src/ProtocolGateway.Core/Mqtt/Settings.cs
+++ b/src/ProtocolGateway.Core/Mqtt/Settings.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
         const string DeviceReceiveAckTimeoutSetting = "DeviceReceiveAckTimeout";
         const string MaxOutboundRetransmissionCountSetting = "MaxOutboundRetransmissionCount";
         const string ServicePropertyPrefixSetting = "ServicePropertyPrefix";
-
+        const string SubscriptionCreationTimeCheckThresholdSetting = "SubscriptionCreationTimeCheckThreshold"; //Threshold of time difference between message IoT Hub enqueued time and subscription creation time
         const string RetainPropertyNameDefaultValue = "mqtt-retain";
         const string DupPropertyNameDefaultValue = "mqtt-dup";
         const string QoSPropertyNameDefaultValue = "mqtt-qos";
@@ -64,6 +64,11 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             this.MaxOutboundRetransmissionCount = retransmissionCount;
 
             this.ServicePropertyPrefix = settingsProvider.GetSetting(ServicePropertyPrefixSetting, string.Empty);
+
+            TimeSpan threshold;
+            this.SubscriptionCreationTimeCheckThreshold = settingsProvider.TryGetTimeSpanSetting(SubscriptionCreationTimeCheckThresholdSetting, out threshold)
+                ? threshold
+                : (TimeSpan?)null;
         }
 
         public int MaxPendingInboundAcknowledgements { get; private set; }
@@ -92,5 +97,11 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
         public int MaxOutboundRetransmissionCount { get; }
 
         public string ServicePropertyPrefix { get; private set; }
+
+        /// <summary>
+        ///     The Protocol Gateway and IoT Hub reside on different servers which can result in a time variance. This threshold can be set to help reduce the restriction
+        ///     on the time difference between subscription creation time (Protocol Gateway) and message enqueued time (IoT Hub).
+        /// </summary>
+        public TimeSpan? SubscriptionCreationTimeCheckThreshold { get; }
     }
 }


### PR DESCRIPTION
Motivation:
The Protocol Gateway and IoT Hub reside on different servers which can
result in a time variance. A threshold setting can be set to help reduce
the restriction
on the time difference between subscription creation time (Protocol
Gateway) and message enqueued time (IoT Hub).

Modifications:
-Added SubscriptionCreationTimeCheckThreshold setting
-Updated TryMatchSubscription to use threshold when checking subscription
creation time against message creation time

Results:
Subscription match will be can be adjusted to be less restrictive.