### PR TITLE
Properly passing ownership (and therefore lifetime management) of mes…

### DIFF
--- a/ProtocolGateway.sln.DotSettings
+++ b/ProtocolGateway.sln.DotSettings
@@ -16,6 +16,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantIfElseBlock/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantNameQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantThisQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantToStringCallForValueType/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SimplifyConditionalTernaryExpression/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StyleCop_002ESA1208/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestUseVarKeywordEvident/@EntryIndexedValue">HINT</s:String>

--- a/src/ProtocolGateway.Core/Mqtt/MessageAsyncProcessor.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MessageAsyncProcessor.cs
@@ -17,9 +17,6 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             this.processFunc = processFunc;
         }
 
-        protected override Task ProcessAsync(IChannelHandlerContext context, T packet, string scope)
-        {
-            return this.processFunc(context, packet);
-        }
+        protected override Task ProcessAsync(IChannelHandlerContext context, T packet, string scope) => this.processFunc(context, packet);
     }
 }

--- a/src/ProtocolGateway.Core/ReadOnlyByteBufferStream.cs
+++ b/src/ProtocolGateway.Core/ReadOnlyByteBufferStream.cs
@@ -19,20 +19,11 @@ namespace Microsoft.Azure.Devices.ProtocolGateway
             this.releaseReferenceOnClosure = releaseReferenceOnClosure;
         }
 
-        public override bool CanRead
-        {
-            get { return true; }
-        }
+        public override bool CanRead => true;
 
-        public override bool CanSeek
-        {
-            get { return false; }
-        }
+        public override bool CanSeek => false;
 
-        public override bool CanWrite
-        {
-            get { return false; }
-        }
+        public override bool CanWrite => false;
 
         public override long Length
         {

--- a/src/ProtocolGateway.IotHubClient/IotHubClientMessage.cs
+++ b/src/ProtocolGateway.IotHubClient/IotHubClientMessage.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.IotHubClient
     using System;
     using System.Collections.Generic;
     using DotNetty.Buffers;
+    using DotNetty.Common.Utilities;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.ProtocolGateway.Messaging;
 
@@ -17,12 +18,6 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.IotHubClient
         {
             this.message = message;
             this.Payload = payload;
-        }
-
-        public IotHubClientMessage(string address, Message message)
-            : this(message, null)
-        {
-            this.Address = address;
         }
 
         public IDictionary<string, string> Properties => this.message.Properties;
@@ -42,12 +37,12 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.IotHubClient
         public void Dispose()
         {
             this.message.Dispose();
-            this.message.BodyStream?.Dispose();
+            if (this.Payload != null)
+            {
+                ReferenceCountUtil.SafeRelease(this.Payload);
+            }
         }
 
-        internal Message ToMessage()
-        {
-            return this.message;
-        }
+        internal Message ToMessage() => this.message;
     }
 }


### PR DESCRIPTION
…sages as processing gets delegated.

Motivation:
It is hard to reason about ownership of messages on ingress in MqttAdapter. Having clear contract of ownership would prevent errors around buffer lifetime management.

Modifications:
- IMessage no longer inherits from IDisposable
- MqttAdapter does not handle message lifetime where it passes a message to MSC (considered transfer of ownership now)
- MessageAsyncProcessorBase now performs SafeRelease on message if processing failed
- IotHubClient cleans up message only if its processing fails in device client

Result:
Ownership model is well-defined and it is much easier to reason about lifetime of a message in a given processing context.