### PR TITLE
Fix message address multiple matching for net standard

### DIFF
--- a/src/ProtocolGateway.IotHubClient/Addressing/ConfigurableMessageAddressConverter.cs
+++ b/src/ProtocolGateway.IotHubClient/Addressing/ConfigurableMessageAddressConverter.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.IotHubClient.Addressing
                     continue;
                 }
 
-                if (matches.Count > 1 && matched)
+                if (matched)
                 {
                     if (CommonEventSource.Log.IsVerboseEnabled)
                     {


### PR DESCRIPTION
it should break when was already matched and matches.Count != 0