### PR TITLE
Fix for issue #74

### DIFF
--- a/src/ProtocolGateway.Core/Mqtt/MqttAdapter.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MqttAdapter.cs
@@ -1025,7 +1025,11 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
             {
                 this.stateFlags |= StateFlags.Closed; // "or" not to interfere with ongoing logic which has to honor Closed state when it's right time to do (case by case)
 
-                PerformanceCounters.ConnectionsCurrent.Decrement();
+                // only decrement connection current counter if the state had connected state in this session 
+                if (this.IsInState(StateFlags.Connected))
+                {
+                    PerformanceCounters.ConnectionsCurrent.Decrement();
+                }
 
                 Queue<Packet> connectQueue = this.connectPendingQueue;
                 if (connectQueue != null)


### PR DESCRIPTION
Connection Current perf counter should only be decremented when the current state had a device connection in past. Otherwise all channel shutdown will decrement the counter causing a negative long value which when exported would have a value 1.8447+e019 (Issue #74 )