### PR TITLE
Update MqttAdapter.LastClientActivityTime on a successful send on the channel

### DIFF
--- a/src/ProtocolGateway.Core/Mqtt/MqttAdapter.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MqttAdapter.cs
@@ -561,6 +561,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                             throw new ProtocolGatewayException(ErrorCode.QoSLevelNotSupported, "Requested QoS level is not supported.");
                     }
                 }
+                this.lastClientActivityTime = DateTime.UtcNow; // note last client activity - used in handling disconnects on keep-alive timeout
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Currently the lastClientActivityTime field on the MqttAdapter, that is used to check if the channel has timed out, is refreshed only on a channel read. However, this causes the channel to timeout, if it is only sending messages. 
This fix is to refresh the lastClientActivityTime on a successful publish to client operation as well.