### PR TITLE
VS 2015 related tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For guidance on customizations and extensibility of the protocol gateway, please
 ### Prerequisites
 The protocol gateway requires an Azure IoT hub to connect to and an Azure Storage account used for persisting state. You can also use the Azure Storage Emulator for the console or cloud hosts running locally.
 
-To build the protocol gateway you need Microsoft Visual Studio 2013 (or later) and Microsoft Azure SDK 2.6 installed on your development machine. For deployment of the protocol gateway you need Microsoft Azure PowerShell installed.
+To build the protocol gateway you need Microsoft Visual Studio 2015 (or later) and Microsoft Azure SDK 2.6 installed on your development machine. For deployment of the protocol gateway you need Microsoft Azure PowerShell installed.
 
 ### Running the Console Host
 The Azure IoT protocol gateway repository contains reference implementations of hosts in the ‘/host’ folder. The console app in this folder hosts a protocol gateway that connects to IoT Hub and starts listening for devices to connect (Note: by default the gateway listens on port 8883 for MQTTS and uses port 5671 for AMQPS traffic).

--- a/build.cmd
+++ b/build.cmd
@@ -10,10 +10,10 @@ IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '%CACHED_NUGET%'"
 
 :vsvarssetup
-if not defined VS120COMNTOOLS goto build
-if not exist "%VS120COMNTOOLS%\VsDevCmd.bat" goto build
-call "%VS120COMNTOOLS%\VsDevCmd.bat"
+if not defined VS140COMNTOOLS goto build
+if not exist "%VS140COMNTOOLS%\VsDevCmd.bat" goto build
+call "%VS140COMNTOOLS%\VsDevCmd.bat"
 
 :build
-%CACHED_NUGET% restore
+%CACHED_NUGET% restore ProtocolGateway.sln
 msbuild ProtocolGateway.sln


### PR DESCRIPTION
Updated build script to use VS 2015 environment variables. Fixes issue #99.

Updated README to reference VS 2015 as a requirement. The project is using C# 6 syntax that is not supported in VS 2013 (at least by default).