### PR TITLE
Update deploy.ps1, to prevent powershell error

### DIFF
--- a/host/deploy.ps1
+++ b/host/deploy.ps1
@@ -276,8 +276,7 @@ if ($diagConfigXml.PublicConfig.StorageAccount)
 $diagnosticsConfigurationPath = (Resolve-Path $diagnosticsConfigurationPath).ToString() + ".final"
 $diagConfigXml.Save($diagnosticsConfigurationPath)
 
-$storageContext = New-AzureStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey
-$diagConfig = New-AzureServiceDiagnosticsExtensionConfig -StorageContext $storageContext -DiagnosticsConfigurationPath $diagnosticsConfigurationPath
+$diagConfig = New-AzureStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey |  New-AzureServiceDiagnosticsExtensionConfig -DiagnosticsConfigurationPath $diagnosticsConfigurationPath
 
 # upgrading or creating a deployment
 $deployment = Execute-Command -Command { Get-AzureDeployment $serviceName $slot } -EEL @($global:resourceNotFound)


### PR DESCRIPTION
Hi,
I've just update the deploy.ps1 file, because when you execute this file you can have an error of complex cmdlet like : 

New-AzureServiceDiagnosticsExtensionConfig : Cannot bind parameter 'StorageContext'. Cannot convert the
"Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext" value of type
"Microsoft.WindowsAzure.Commands.Storage.AzureStorageContext" to type
"Microsoft.WindowsAzure.Commands.Common.Storage.AzureStorageContext".
At D:\Samples\azure-iot-protocol-gateway\host\deploy.ps1:280 char:74

So with this new instruction, I hope it' will prevent this bug to others people
(I recently saw that I'm not the only one in this case because I asked for some help (for another problem), and the people who tried to helped me got the same issue at this point).

PS : It's the first time that i do a pull request, could you please tell me if i made something wrong ?

Best regards,

Reynholds.

