### PR TITLE
Change the way MqttAdapter handles saving of transient sessions.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 #### 3.0.0 July 24, 2019
-- Change the way `MqttAdapter` handles transient sessions. `MqttAdapter.ProcessPendingSubscriptionChanges` will now always call `ISessionStatePersistenceProvider.SetAsync` irrespective of the session being transient or not. State handling of transient sessions is not left to the implementation of '`ISessionStatePersistenceProvider`
+- Change the way `MqttAdapter` handles transient sessions. `MqttAdapter.ProcessPendingSubscriptionChanges` will now always call `ISessionStatePersistenceProvider.SetAsync` irrespective of the session being transient or not. State handling of transient sessions is now left to the implementation of '`ISessionStatePersistenceProvider`
 -  `MqttAdapter.EstablishSessionStateAsync` also now checks if the existing session is transient and deletes it when true.
 - `BlobSessionStatePersistenceProvider.SetAsync` will return instead of throwing if the state is transient 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 3.0.0 July 24, 2019
+- Change the way `MqttAdapter` handles transient sessions. `MqttAdapter.ProcessPendingSubscriptionChanges` will now always call `ISessionStatePersistenceProvider.SetAsync` irrespective of the session being transient or not. State handling of transient sessions is not left to the implementation of '`ISessionStatePersistenceProvider`
+-  `MqttAdapter.EstablishSessionStateAsync` also now checks if the existing session is transient and deletes it when true.
+- `BlobSessionStatePersistenceProvider.SetAsync` will return instead of throwing if the state is transient 
+
 #### 1.0.1 March 12
 - Azure Table QoS 2 persistence provider uses proper query API to retrieve only relevant row.
 - QoS 2 persistence provider API is modified to work with SequenceNumber instead of MessageId.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,5 @@
 #### 3.0.0 July 24, 2019
 - Change the way `MqttAdapter` handles transient sessions. `MqttAdapter.ProcessPendingSubscriptionChanges` will now always call `ISessionStatePersistenceProvider.SetAsync` irrespective of the session being transient or not. State handling of transient sessions is now left to the implementation of '`ISessionStatePersistenceProvider`
--  `MqttAdapter.EstablishSessionStateAsync` also now checks if the existing session is transient and deletes it when true.
 - `BlobSessionStatePersistenceProvider.SetAsync` will return instead of throwing if the state is transient 
 
 #### 1.0.1 March 12

--- a/src/ProtocolGateway.Core/Mqtt/MqttAdapter.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MqttAdapter.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                     queue.Clear();
 
                     // save updated session state, make it current once successfully set
-                    // we let the session manager decide how to handle transient state...
+                    // we let the session manager decide how to handle transient state.
                     await this.sessionStateManager.SetAsync(this.identity, newState);
 
                     this.sessionState = newState;

--- a/src/ProtocolGateway.Providers.CloudStorage/BlobSessionStatePersistenceProvider.cs
+++ b/src/ProtocolGateway.Providers.CloudStorage/BlobSessionStatePersistenceProvider.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage
 
             if (state.IsTransient)
             {
-                throw new ArgumentException("Cannot persist transient Session State object.", "sessionState");
+                return;
             }
 
             CloudBlockBlob blob = this.container.GetBlockBlobReference(identity.Id);


### PR DESCRIPTION
1) We need to let the Session state manager decide what  it needs to do with transient sessions and how. To that effect - we will remove the isTransient check and always call the SetAsync on the sessionStateManager
2) Given that we are lettitng the sessionStateManager decide what to do with transient sessions, we also need to provide a way to clean up during establishing a clean session... Assuming that GetAsync can potentially return a previous session that can be transient, we need to also check for the "transient-ness" of the previous session and delete it if necessary!

BlobStatePersistanceProvider :
Changed the code in BlobStatePersistanceProvider to return instead of throwing if we call the set async on a session that is transient.