### PR TITLE
Use inner exception

### DIFF
--- a/src/ProtocolGateway.Core/Mqtt/MqttAdapter.cs
+++ b/src/ProtocolGateway.Core/Mqtt/MqttAdapter.cs
@@ -1107,7 +1107,8 @@ namespace Microsoft.Azure.Devices.ProtocolGateway.Mqtt
                 var ex = task.Exception.InnerException as ChannelMessageProcessingException;
                 if (ex != null)
                 {
-                    ShutdownOnError(ex.Context, scope, task.Exception);
+                    // we need to unmask the ChannelMessageProcessingException to get the real exception
+                    ShutdownOnError(ex.Context, scope, ex.InnerException);
                 }
                 else
                 {

--- a/src/ProtocolGateway.Core/ProtocolGateway.Core.NetStandard.csproj
+++ b/src/ProtocolGateway.Core/ProtocolGateway.Core.NetStandard.csproj
@@ -9,8 +9,8 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
     <AssemblyName>Microsoft.Azure.Devices.ProtocolGateway.Core</AssemblyName>
     <RootNamespace>Microsoft.Azure.Devices.ProtocolGateway.Core</RootNamespace>
-    <Version>2.0.1.0</Version>
-    <PackageVersion>2.0.1</PackageVersion>
+    <Version>2.1.4.0</Version>
+    <PackageVersion>2.1.4</PackageVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Company>Microsoft</Company>
     <Product>Microsoft Azure IoT protocol gateway</Product>

--- a/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.NetStandard.csproj
+++ b/src/ProtocolGateway.IotHubClient/ProtocolGateway.IotHubClient.NetStandard.csproj
@@ -9,8 +9,8 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
     <AssemblyName>Microsoft.Azure.Devices.ProtocolGateway.IotHubClient</AssemblyName>
     <RootNamespace>Microsoft.Azure.Devices.ProtocolGateway.IotHubClient</RootNamespace>
-    <Version>2.0.1.0</Version>
-    <PackageVersion>2.0.1</PackageVersion>
+    <Version>2.1.4.0</Version>
+    <PackageVersion>2.1.4</PackageVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Company>Microsoft</Company>
     <Product>Microsoft Azure IoT protocol gateway</Product>

--- a/src/ProtocolGateway.Providers.CloudStorage/ProtocolGateway.Providers.CloudStorage.NetStandard.csproj
+++ b/src/ProtocolGateway.Providers.CloudStorage/ProtocolGateway.Providers.CloudStorage.NetStandard.csproj
@@ -9,8 +9,8 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
     <AssemblyName>Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage</AssemblyName>
     <RootNamespace>Microsoft.Azure.Devices.ProtocolGateway.Providers.CloudStorage</RootNamespace>
-    <Version>2.0.1.0</Version>
-    <PackageVersion>2.0.1</PackageVersion>
+    <Version>2.1.4.0</Version>
+    <PackageVersion>2.1.4</PackageVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Company>Microsoft</Company>
     <Product>Microsoft Azure IoT protocol gateway</Product>


### PR DESCRIPTION
It shrinks the exception to Gateway client from

Message: System.AggregateException: One or more errors occurred. ---> Microsoft.Azure.Devices.ProtocolGateway.Mqtt.ChannelMessageProcessingException ---> Microsoft.Azure.Devices.Common.Core.Exceptions.IotHubException

to Microsoft.Azure.Devices.Common.Core.Exceptions.IotHubException